### PR TITLE
Add dual pool support with registration-based routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@
 
 ### Added
 
+- **Dual Pool Support** - Separate pools for CPU-bound and I/O-bound operations
+  - `default` pool - For quick CPU-bound operations, sized to number of schedulers
+  - `io` pool - For I/O-bound operations, larger pool (default: 10) for concurrency
+  - `py:call(io, Module, Func, Args)` - Execute on the io pool
+  - `py:call(io, Module, Func, Args, Kwargs)` - Execute with kwargs on io pool
+  - Registration-based routing (no call site changes needed):
+    - `py:register_pool(io, requests)` - Route all `requests.*` calls to io pool
+    - `py:register_pool(io, {aiohttp, get})` - Route specific function to io pool
+    - `py:unregister_pool(Module)` - Remove module registration
+    - `py:unregister_pool({Module, Func})` - Remove function registration
+    - Automatic routing: `py:call(requests, get, [Url])` goes to io pool when registered
+  - `py_context_router:start_pool/2,3` - Start named pools programmatically
+  - `py_context_router:stop_pool/1` - Stop a named pool
+  - `py_context_router:pool_started/1` - Check if a pool is running
+  - `py_context_router:get_context(Pool)` - Get context from a named pool
+  - `py_context_router:num_contexts(Pool)` - Get pool size
+  - `py_context_router:contexts(Pool)` - Get all contexts in a pool
+  - `py_context_router:lookup_pool(Module, Func)` - Query pool routing
+  - Configuration via application env:
+    ```erlang
+    {erlang_python, [
+        {io_pool_size, 10},      % Size of io pool (default: 10)
+        {io_pool_mode, worker}   % Mode for io pool (default: auto)
+    ]}.
+    ```
+  - Backward compatible: existing code using `py:call/3,4,5` works unchanged
+  - New test suite: `test/py_pool_SUITE.erl`
+
 - **Channel API** - Bidirectional message passing between Erlang and Python
   - `py_channel:new/0,1` - Create channels with optional backpressure (`max_size`)
   - `py_channel:send/2` - Send Erlang terms to Python (returns `busy` on backpressure)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -395,8 +395,29 @@ end.
 
 See [Security](security.md) for details on blocked operations and recommended alternatives.
 
+## Dual Pool Support
+
+erlang_python provides two pools to separate CPU-bound and I/O-bound operations:
+
+```erlang
+%% Register entire modules to io pool
+py:register_pool(io, requests).
+py:register_pool(io, psycopg2).
+
+%% Or register specific callables
+py:register_pool(io, {db, query}).        %% Only db.query goes to io pool
+
+%% Calls automatically route to the right pool
+{ok, 4.0} = py:call(math, sqrt, [16]).       %% -> default pool (fast)
+{ok, Resp} = py:call(requests, get, [Url]).  %% -> io pool (module registered)
+{ok, Rows} = py:call(db, query, [Sql]).      %% -> io pool (callable registered)
+```
+
+This prevents slow HTTP requests from blocking quick math operations. See [Dual Pool Support](pools.md) for configuration and advanced usage.
+
 ## Next Steps
 
+- See [Dual Pool Support](pools.md) for separating CPU and I/O operations
 - See [Type Conversion](type-conversion.md) for detailed type mapping
 - See [Context Affinity](context-affinity.md) for preserving Python state
 - See [Streaming](streaming.md) for working with generators

--- a/docs/pools.md
+++ b/docs/pools.md
@@ -1,0 +1,288 @@
+# Dual Pool Support
+
+This guide covers erlang_python's dual pool architecture for separating CPU-bound and I/O-bound Python operations.
+
+## Overview
+
+erlang_python provides two separate pools of Python contexts:
+
+| Pool | Purpose | Default Size | Use Case |
+|------|---------|--------------|----------|
+| `default` | Quick CPU-bound operations | Number of schedulers | Math, string processing, data transformation |
+| `io` | Slow I/O-bound operations | 10 | HTTP requests, database queries, file I/O |
+
+This separation prevents slow I/O operations from blocking quick CPU operations.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                         py:call/3,4,5                             │
+│                              │                                    │
+│                              ▼                                    │
+│                    ┌─────────────────┐                           │
+│                    │  lookup_pool()  │                           │
+│                    │  (registration) │                           │
+│                    └────────┬────────┘                           │
+│                             │                                    │
+│              ┌──────────────┴──────────────┐                     │
+│              ▼                              ▼                     │
+│     ┌────────────────┐             ┌────────────────┐            │
+│     │  default pool  │             │    io pool     │            │
+│     │  (N contexts)  │             │  (10 contexts) │            │
+│     └────────────────┘             └────────────────┘            │
+│              │                              │                     │
+│     ┌────────┴────────┐            ┌────────┴────────┐           │
+│     ▼        ▼        ▼            ▼        ▼        ▼           │
+│   Ctx1    Ctx2    CtxN          Ctx1    Ctx2    Ctx10           │
+│   (math)  (json)  (...)         (http)  (db)   (...)            │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## Basic Usage
+
+### Explicit Pool Selection
+
+Specify the pool directly in the call:
+
+```erlang
+%% Use default pool (quick operations)
+{ok, 4.0} = py:call(default, math, sqrt, [16]).
+
+%% Use io pool (slow operations)
+{ok, Response} = py:call(io, requests, get, [Url]).
+
+%% With keyword arguments
+{ok, Data} = py:call(io, requests, get, [Url], #{timeout => 30}).
+```
+
+### Registration-Based Routing
+
+Register modules or specific functions to automatically route to a specific pool:
+
+```erlang
+%% Register entire module to io pool (all functions in module)
+ok = py:register_pool(io, requests).
+ok = py:register_pool(io, aiohttp).
+ok = py:register_pool(io, psycopg2).
+
+%% Register specific module.function to io pool
+ok = py:register_pool(io, {urllib, urlopen}).    %% Only urllib.urlopen
+ok = py:register_pool(io, {httpx, 'get'}).       %% Only httpx.get
+ok = py:register_pool(io, {db, query}).          %% Only db.query
+
+%% Now calls route automatically - no code changes needed
+{ok, 4.0} = py:call(math, sqrt, [16]).           %% -> default pool
+{ok, Resp} = py:call(requests, get, [Url]).      %% -> io pool (module registered)
+{ok, Rows} = py:call(db, query, [Sql]).          %% -> io pool (function registered)
+{ok, Data} = py:call(db, connect, [Dsn]).        %% -> default pool (only db.query registered)
+```
+
+### Unregistering
+
+```erlang
+%% Remove module registration
+ok = py:unregister_pool(requests).
+
+%% Remove function registration
+ok = py:unregister_pool({urllib, urlopen}).
+```
+
+## Registration Priority
+
+Function-specific registrations take priority over module-wide registrations:
+
+```erlang
+%% Register all json functions to io pool
+ok = py:register_pool(io, json).
+
+%% But keep json.dumps on default pool (it's fast)
+ok = py:register_pool(default, {json, dumps}).
+
+%% Results:
+io = py_context_router:lookup_pool(json, loads).   %% Module registration
+default = py_context_router:lookup_pool(json, dumps).  %% Function override
+```
+
+## API Reference
+
+### High-Level API (py module)
+
+```erlang
+%% Register entire module to pool (all callables in the module)
+-spec register_pool(Pool, Module) -> ok when
+    Pool :: default | io | atom(),
+    Module :: atom().
+
+%% Register specific callable (module.function) to pool
+-spec register_pool(Pool, {Module, Callable}) -> ok when
+    Pool :: default | io | atom(),
+    Module :: atom(),
+    Callable :: atom().
+
+%% Unregister module or specific callable
+-spec unregister_pool(Module | {Module, Callable}) -> ok.
+
+%% Call on specific pool
+-spec call(Pool, Module, Func, Args) -> {ok, Result} | {error, Reason}.
+-spec call(Pool, Module, Func, Args, Kwargs) -> {ok, Result} | {error, Reason}.
+```
+
+### Low-Level API (py_context_router module)
+
+```erlang
+%% Pool management
+-spec start_pool(Pool, Size) -> {ok, [pid()]} | {error, term()}.
+-spec start_pool(Pool, Size, Mode) -> {ok, [pid()]} | {error, term()}.
+-spec stop_pool(Pool) -> ok.
+-spec pool_started(Pool) -> boolean().
+
+%% Context access
+-spec get_context(Pool) -> pid().
+-spec num_contexts(Pool) -> non_neg_integer().
+-spec contexts(Pool) -> [pid()].
+
+%% Registration
+-spec register_pool(Pool, Module) -> ok.
+-spec register_pool(Pool, Module, Func) -> ok.
+-spec unregister_pool(Module) -> ok.
+-spec unregister_pool(Module, Func) -> ok.
+-spec lookup_pool(Module, Func) -> Pool.
+-spec list_pool_registrations() -> [{{Module, Func | '_'}, Pool}].
+```
+
+## Configuration
+
+Configure pool sizes via application environment:
+
+```erlang
+%% sys.config
+[
+    {erlang_python, [
+        %% Default pool size (default: erlang:system_info(schedulers))
+        {default_pool_size, 8},
+
+        %% IO pool size (default: 10)
+        {io_pool_size, 20},
+
+        %% IO pool mode: auto | subinterp | worker (default: auto)
+        {io_pool_mode, worker}
+    ]}
+].
+```
+
+### Runtime Configuration
+
+```erlang
+%% Start additional custom pool
+{ok, _} = py_context_router:start_pool(gpu, 2, worker).
+
+%% Register GPU operations
+ok = py:register_pool(gpu, torch).
+ok = py:register_pool(gpu, tensorflow).
+```
+
+## Use Cases
+
+### Web Application with Database
+
+```erlang
+%% At application startup
+init_pools() ->
+    %% Register I/O-heavy modules
+    py:register_pool(io, requests),
+    py:register_pool(io, httpx),
+    py:register_pool(io, psycopg2),
+    py:register_pool(io, redis),
+    ok.
+
+%% In request handler - no pool awareness needed
+handle_request(UserId) ->
+    %% Fast: uses default pool
+    {ok, Hash} = py:call(hashlib, sha256, [UserId]),
+
+    %% Slow: automatically uses io pool
+    {ok, User} = py:call(psycopg2, fetchone, [<<"SELECT * FROM users WHERE id = ?">>, [UserId]]),
+
+    %% Fast: uses default pool
+    {ok, Json} = py:call(json, dumps, [User]),
+    {ok, Json}.
+```
+
+### ML Pipeline with I/O
+
+```erlang
+%% Register I/O operations
+py:register_pool(io, boto3),        %% S3 access
+py:register_pool(io, requests),      %% API calls
+
+%% ML operations stay on default pool (CPU-intensive)
+%% I/O operations go to io pool
+
+process_batch(Items) ->
+    %% Parallel fetch from S3 (io pool)
+    Futures = [py:cast(boto3, download_file, [Key]) || Key <- Items],
+    Files = [py:await(F) || F <- Futures],
+
+    %% Process with ML model (default pool - doesn't block I/O)
+    [{ok, _} = py:call(model, predict, [File]) || File <- Files].
+```
+
+## Performance Considerations
+
+### Pool Sizing
+
+| Workload | default Pool | io Pool |
+|----------|--------------|---------|
+| CPU-heavy | Schedulers | Small (5-10) |
+| I/O-heavy | Small (2-4) | Large (20-50) |
+| Mixed | Schedulers | 10-20 |
+
+### When to Use Registration
+
+**Use registration when:**
+- You have clear I/O-bound modules (HTTP clients, database drivers)
+- You want transparent routing without changing call sites
+- Multiple call sites use the same module
+
+**Use explicit pool selection when:**
+- A function's pool depends on arguments
+- You need fine-grained control per-call
+- Testing or debugging specific pools
+
+## Monitoring
+
+```erlang
+%% Check pool status
+true = py_context_router:pool_started(default),
+true = py_context_router:pool_started(io).
+
+%% Check pool sizes
+DefaultSize = py_context_router:num_contexts(default),
+IoSize = py_context_router:num_contexts(io).
+
+%% List all registrations
+Registrations = py_context_router:list_pool_registrations().
+%% => [{{requests, '_'}, io}, {{json, dumps}, default}, ...]
+
+%% Check which pool a call would use
+io = py_context_router:lookup_pool(requests, get).
+default = py_context_router:lookup_pool(math, sqrt).
+```
+
+## Backward Compatibility
+
+Existing code using `py:call/3,4,5` without pool registration continues to work unchanged, using the default pool:
+
+```erlang
+%% These all use the default pool (backward compatible)
+{ok, 4.0} = py:call(math, sqrt, [16]).
+{ok, Data} = py:call(json, dumps, [#{a => 1}]).
+{ok, 6} = py:eval(<<"2 + 4">>).
+```
+
+## See Also
+
+- [Scalability](scalability.md) - Execution modes and parallel execution
+- [Getting Started](getting-started.md) - Basic usage
+- [Asyncio](asyncio.md) - Async I/O with event loops

--- a/src/erlang_python_app.erl
+++ b/src/erlang_python_app.erl
@@ -23,7 +23,8 @@ start(_StartType, _StartArgs) ->
     erlang_python_sup:start_link().
 
 stop(_State) ->
-    %% Stop contexts before application shutdown to ensure proper cleanup
+    %% Stop pools before application shutdown to ensure proper cleanup
     %% of subinterpreters before NIF resources are garbage collected
-    catch py:stop_contexts(),
+    catch py_context_router:stop_pool(io),
+    catch py_context_router:stop_pool(default),
     ok.

--- a/src/py.erl
+++ b/src/py.erl
@@ -131,7 +131,10 @@
     to_term/1,
     is_ref/1,
     %% File descriptor utilities
-    dup_fd/1
+    dup_fd/1,
+    %% Pool registration API
+    register_pool/2,
+    unregister_pool/1
 ]).
 
 -type py_result() :: {ok, term()} | {error, term()}.
@@ -155,54 +158,66 @@
 call(Module, Func, Args) ->
     call(Module, Func, Args, #{}).
 
-%% @doc Call a Python function with keyword arguments.
+%% @doc Call a Python function with keyword arguments or on a named pool.
 %%
-%% When the first argument is a pid (context), calls using the new
-%% process-per-context architecture.
+%% This function has multiple signatures:
+%% - `call(Ctx, Module, Func, Args)' - Call using a specific context pid
+%% - `call(Pool, Module, Func, Args)' - Call using a named pool (default, io, etc.)
+%% - `call(Module, Func, Args, Kwargs)' - Call with keyword arguments on default pool
 %%
-%% @param CtxOrModule Context pid or Python module
+%% @param CtxOrPoolOrModule Context pid, pool name, or Python module
 %% @param ModuleOrFunc Python module or function name
 %% @param FuncOrArgs Function name or arguments list
 %% @param ArgsOrKwargs Arguments list or keyword arguments
 -spec call(pid(), py_module(), py_func(), py_args()) -> py_result()
+    ; (py_context_router:pool_name(), py_module(), py_func(), py_args()) -> py_result()
     ; (py_module(), py_func(), py_args(), py_kwargs()) -> py_result().
 call(Ctx, Module, Func, Args) when is_pid(Ctx) ->
     py_context:call(Ctx, Module, Func, Args, #{});
+call(Pool, Module, Func, Args) when is_atom(Pool), is_atom(Func) ->
+    %% Pool-based call (e.g., py:call(io, math, sqrt, [16]))
+    call(Pool, Module, Func, Args, #{});
 call(Module, Func, Args, Kwargs) ->
     call(Module, Func, Args, Kwargs, ?DEFAULT_TIMEOUT).
 
-%% @doc Call a Python function with keyword arguments and custom timeout.
+%% @doc Call a Python function with keyword arguments and optional timeout or pool.
 %%
-%% When the first argument is a pid (context), calls using the new
-%% process-per-context architecture with options map.
+%% This function has multiple signatures:
+%% - `call(Ctx, Module, Func, Args, Opts)' - Call using context with options map
+%% - `call(Pool, Module, Func, Args, Kwargs)' - Call using named pool with kwargs
+%% - `call(Module, Func, Args, Kwargs, Timeout)' - Call on default pool with timeout
 %%
 %% Timeout is in milliseconds. Use `infinity' for no timeout.
 %% Rate limited via ETS-based semaphore to prevent overload.
 -spec call(pid(), py_module(), py_func(), py_args(), map()) -> py_result()
+    ; (py_context_router:pool_name(), py_module(), py_func(), py_args(), py_kwargs()) -> py_result()
     ; (py_module(), py_func(), py_args(), py_kwargs(), timeout()) -> py_result().
 call(Ctx, Module, Func, Args, Opts) when is_pid(Ctx), is_map(Opts) ->
     Kwargs = maps:get(kwargs, Opts, #{}),
     Timeout = maps:get(timeout, Opts, infinity),
     py_context:call(Ctx, Module, Func, Args, Kwargs, Timeout);
+call(Pool, Module, Func, Args, Kwargs) when is_atom(Pool), is_atom(Func), is_map(Kwargs) ->
+    %% Pool-based call with kwargs (e.g., py:call(io, math, pow, [2, 3], #{round => true}))
+    do_pool_call(Pool, Module, Func, Args, Kwargs, ?DEFAULT_TIMEOUT);
 call(Module, Func, Args, Kwargs, Timeout) ->
-    %% Acquire semaphore slot before making the call
+    %% Look up which pool to use based on registered module/function
+    Pool = py_context_router:lookup_pool(Module, Func),
+    do_pool_call(Pool, Module, Func, Args, Kwargs, Timeout).
+
+%% @private
+%% Call using a named pool with semaphore protection
+do_pool_call(Pool, Module, Func, Args, Kwargs, Timeout) ->
     case py_semaphore:acquire(Timeout) of
         ok ->
             try
-                do_call(Module, Func, Args, Kwargs, Timeout)
+                Ctx = py_context_router:get_context(Pool),
+                py_context:call(Ctx, Module, Func, Args, Kwargs, Timeout)
             after
                 py_semaphore:release()
             end;
         {error, max_concurrent} ->
             {error, {overloaded, py_semaphore:current(), py_semaphore:max_concurrent()}}
     end.
-
-%% @private
-%% Always route through context process - it handles callbacks inline using
-%% suspension-based approach (no separate callback handler, no blocking)
-do_call(Module, Func, Args, Kwargs, Timeout) ->
-    Ctx = py_context_router:get_context(),
-    py_context:call(Ctx, Module, Func, Args, Kwargs, Timeout).
 
 %% @doc Evaluate a Python expression and return the result.
 -spec eval(string() | binary()) -> py_result().
@@ -1319,4 +1334,47 @@ is_ref(Term) ->
 -spec dup_fd(integer()) -> {ok, integer()} | {error, term()}.
 dup_fd(Fd) when is_integer(Fd) ->
     py_nif:dup_fd(Fd).
+
+%%% ============================================================================
+%%% Pool Registration API
+%%% ============================================================================
+
+%% @doc Register a module or module/function to use a specific pool.
+%%
+%% After registration, calls to the module (or specific function) are
+%% automatically routed to the registered pool without changing call sites.
+%%
+%% Examples:
+%% ```
+%% %% Route all requests.* calls to io pool
+%% py:register_pool(io, requests).
+%%
+%% %% Route only aiohttp.get to io pool
+%% py:register_pool(io, {aiohttp, get}).
+%%
+%% %% Calls now automatically route to the correct pool
+%% {ok, Resp} = py:call(requests, get, [Url]).  %% -> io pool
+%% {ok, 4.0} = py:call(math, sqrt, [16]).       %% -> default pool
+%% '''
+%%
+%% @param Pool Pool name (io, default, or custom)
+%% @param ModuleOrTuple Module atom or {Module, Func} tuple
+%% @returns ok
+-spec register_pool(py_context_router:pool_name(), atom() | {atom(), atom()}) -> ok.
+register_pool(Pool, Module) when is_atom(Pool), is_atom(Module) ->
+    py_context_router:register_pool(Pool, Module);
+register_pool(Pool, {Module, Func}) when is_atom(Pool), is_atom(Module), is_atom(Func) ->
+    py_context_router:register_pool(Pool, Module, Func).
+
+%% @doc Unregister a module or module/function from pool routing.
+%%
+%% After unregistering, calls return to using the default pool.
+%%
+%% @param ModuleOrTuple Module atom or {Module, Func} tuple
+%% @returns ok
+-spec unregister_pool(atom() | {atom(), atom()}) -> ok.
+unregister_pool(Module) when is_atom(Module) ->
+    py_context_router:unregister_pool(Module);
+unregister_pool({Module, Func}) when is_atom(Module), is_atom(Func) ->
+    py_context_router:unregister_pool(Module, Func).
 

--- a/src/py_context_init.erl
+++ b/src/py_context_init.erl
@@ -15,28 +15,55 @@
 %%% @doc Initializes the context router during application startup.
 %%%
 %%% This module provides a supervisor-compatible start function that
-%%% initializes the context router and returns `ignore' (since no
+%%% initializes the context pools and returns `ignore' (since no
 %%% process needs to stay running after initialization).
+%%%
+%%% == Pools ==
+%%%
+%%% Two pools are started by default:
+%%% - `default' - For quick CPU-bound operations, sized to number of schedulers
+%%% - `io' - For I/O-bound operations, larger pool (default: 10) for concurrency
+%%%
+%%% Pool sizes can be configured via application env:
+%%% ```
+%%% {erlang_python, [
+%%%     {default_pool_size, 4},        % Number of contexts (default: schedulers)
+%%%     {io_pool_size, 10},            % I/O pool size (default: 10)
+%%%     {io_pool_mode, worker}         % Mode for io pool (default: auto)
+%%% ]}.
+%%% '''
 %%% @private
 -module(py_context_init).
 
 -export([start_link/1]).
 
-%% @doc Start the context router.
+%% @doc Start the context pools.
 %%
 %% This function is called by the supervisor to initialize the
-%% py_context_router. After starting the contexts, it returns
+%% py_context_router pools. After starting the contexts, it returns
 %% `ignore' since no process needs to remain running.
 %%
-%% @param Opts Options to pass to py_context_router:start/1
+%% @param Opts Options for the default pool
 %% @returns {ok, pid()} | ignore | {error, Reason}
 -spec start_link(map()) -> {ok, pid()} | ignore | {error, term()}.
 start_link(Opts) ->
-    case py_context_router:start(Opts) of
-        {ok, _Contexts} ->
-            %% The contexts are supervised by py_context_sup
-            %% We don't need a process here, just return ignore
-            ignore;
+    %% Start default pool
+    DefaultSize = maps:get(contexts, Opts, erlang:system_info(schedulers)),
+    DefaultMode = maps:get(mode, Opts, auto),
+
+    case py_context_router:start_pool(default, DefaultSize, DefaultMode) of
+        {ok, _DefaultContexts} ->
+            %% Start I/O pool if configured
+            IoSize = application:get_env(erlang_python, io_pool_size, 10),
+            IoMode = application:get_env(erlang_python, io_pool_mode, auto),
+            case py_context_router:start_pool(io, IoSize, IoMode) of
+                {ok, _IoContexts} ->
+                    %% The contexts are supervised by py_context_sup
+                    %% We don't need a process here, just return ignore
+                    ignore;
+                {error, IoReason} ->
+                    {error, {io_pool_start_failed, IoReason}}
+            end;
         {error, Reason} ->
-            {error, Reason}
+            {error, {default_pool_start_failed, Reason}}
     end.

--- a/src/py_context_router.erl
+++ b/src/py_context_router.erl
@@ -64,29 +64,59 @@
     get_context/0,
     get_context/1,
     bind_context/1,
+    bind_context/2,
     unbind_context/0,
+    unbind_context/1,
     num_contexts/0,
-    contexts/0
+    num_contexts/1,
+    contexts/0,
+    contexts/1,
+    %% Pool management
+    start_pool/2,
+    start_pool/3,
+    stop_pool/1,
+    pool_started/1,
+    %% Pool registration (route module/func to specific pools)
+    register_pool/2,
+    register_pool/3,
+    unregister_pool/1,
+    unregister_pool/2,
+    lookup_pool/2,
+    list_pool_registrations/0,
+    init_pool_registry/0
 ]).
 
-%% Persistent term keys
+%% Persistent term keys (pool-aware)
+-define(POOL_SIZE_KEY(Pool), {?MODULE, pool_size, Pool}).
+-define(POOL_CONTEXT_KEY(Pool, N), {?MODULE, pool_context, Pool, N}).
+-define(POOL_CONTEXTS_KEY(Pool), {?MODULE, pool_contexts, Pool}).
+
+%% Legacy keys for backward compatibility (default pool)
 -define(NUM_CONTEXTS_KEY, {?MODULE, num_contexts}).
 -define(CONTEXT_KEY(N), {?MODULE, context, N}).
 -define(CONTEXTS_KEY, {?MODULE, all_contexts}).
 
-%% Process dictionary key for bound context
--define(BOUND_CONTEXT_KEY, py_bound_context).
+%% Process dictionary key for bound context (pool-aware)
+-define(BOUND_CONTEXT_KEY(Pool), {py_bound_context, Pool}).
+-define(BOUND_CONTEXT_KEY, py_bound_context).  %% Legacy for default pool
+
+%% Default pool name
+-define(DEFAULT_POOL, default).
+
+%% Pool registry persistent term key
+-define(POOL_REGISTRY_KEY, {?MODULE, pool_registry}).
 
 %% ============================================================================
 %% Types
 %% ============================================================================
 
+-type pool_name() :: default | io | atom().
 -type start_opts() :: #{
     contexts => pos_integer(),
     mode => py_context:context_mode()
 }.
 
--export_type([start_opts/0]).
+-export_type([start_opts/0, pool_name/0]).
 
 %% ============================================================================
 %% API
@@ -112,10 +142,141 @@ start() ->
 %% @returns {ok, [Context]} | {error, Reason}
 -spec start(start_opts()) -> {ok, [pid()]} | {error, term()}.
 start(Opts) ->
-    %% Check if contexts are already running (idempotent)
-    case persistent_term:get(?CONTEXTS_KEY, undefined) of
+    NumContexts = maps:get(contexts, Opts, erlang:system_info(schedulers)),
+    Mode = maps:get(mode, Opts, auto),
+    %% Delegate to start_pool for the default pool
+    start_pool(?DEFAULT_POOL, NumContexts, Mode).
+
+%% @doc Stop the context router.
+%%
+%% Stops the default pool and removes persistent_term entries.
+-spec stop() -> ok.
+stop() ->
+    stop_pool(?DEFAULT_POOL).
+
+%% @doc Check if contexts have been started and are still alive.
+%%
+%% @returns true if the default pool is running, false otherwise
+-spec is_started() -> boolean().
+is_started() ->
+    pool_started(?DEFAULT_POOL).
+
+%% @doc Get the context for the current process from the default pool.
+%%
+%% If the process has a bound context, returns that context.
+%% Otherwise, selects a context based on the current scheduler ID.
+%%
+%% @returns Context pid
+-spec get_context() -> pid().
+get_context() ->
+    get_context(?DEFAULT_POOL).
+
+%% @doc Get a context by index or from a named pool.
+%%
+%% When called with an integer, gets the Nth context from the default pool.
+%% When called with an atom, gets a scheduler-affinity context from that pool.
+%%
+%% @param NOrPool Context index (1 to num_contexts) or pool name
+%% @returns Context pid
+-spec get_context(pos_integer() | pool_name()) -> pid().
+get_context(N) when is_integer(N), N > 0 ->
+    %% Legacy: get Nth context from default pool
+    persistent_term:get(?POOL_CONTEXT_KEY(?DEFAULT_POOL, N));
+get_context(Pool) when is_atom(Pool) ->
+    %% Get context from named pool
+    case get(?BOUND_CONTEXT_KEY(Pool)) of
         undefined ->
-            do_start(Opts);
+            select_by_scheduler(Pool);
+        Ctx ->
+            Ctx
+    end.
+
+%% @doc Bind a context to the current process for the default pool.
+%%
+%% After binding, `get_context/0' will always return this context
+%% instead of selecting by scheduler.
+%%
+%% @param Ctx Context pid to bind
+%% @returns ok
+-spec bind_context(pid()) -> ok.
+bind_context(Ctx) when is_pid(Ctx) ->
+    bind_context(?DEFAULT_POOL, Ctx).
+
+%% @doc Bind a context to the current process for a specific pool.
+%%
+%% @param Pool Pool name
+%% @param Ctx Context pid to bind
+%% @returns ok
+-spec bind_context(pool_name(), pid()) -> ok.
+bind_context(Pool, Ctx) when is_atom(Pool), is_pid(Ctx) ->
+    put(?BOUND_CONTEXT_KEY(Pool), Ctx),
+    ok.
+
+%% @doc Unbind the current process's context from the default pool.
+%%
+%% After unbinding, `get_context/0' will return to scheduler-based
+%% selection.
+%%
+%% @returns ok
+-spec unbind_context() -> ok.
+unbind_context() ->
+    unbind_context(?DEFAULT_POOL).
+
+%% @doc Unbind the current process's context from a specific pool.
+%%
+%% @param Pool Pool name
+%% @returns ok
+-spec unbind_context(pool_name()) -> ok.
+unbind_context(Pool) when is_atom(Pool) ->
+    erase(?BOUND_CONTEXT_KEY(Pool)),
+    ok.
+
+%% @doc Get the number of contexts in the default pool.
+-spec num_contexts() -> non_neg_integer().
+num_contexts() ->
+    num_contexts(?DEFAULT_POOL).
+
+%% @doc Get the number of contexts in a pool.
+-spec num_contexts(pool_name()) -> non_neg_integer().
+num_contexts(Pool) when is_atom(Pool) ->
+    persistent_term:get(?POOL_SIZE_KEY(Pool), 0).
+
+%% @doc Get all context pids from the default pool.
+-spec contexts() -> [pid()].
+contexts() ->
+    contexts(?DEFAULT_POOL).
+
+%% @doc Get all context pids from a pool.
+-spec contexts(pool_name()) -> [pid()].
+contexts(Pool) when is_atom(Pool) ->
+    persistent_term:get(?POOL_CONTEXTS_KEY(Pool), []).
+
+%% ============================================================================
+%% Pool Management
+%% ============================================================================
+
+%% @doc Start a named pool with given size.
+%%
+%% @param Pool Pool name (default, io, or custom)
+%% @param Size Number of contexts in the pool
+%% @returns {ok, [Context]} | {error, Reason}
+-spec start_pool(pool_name(), pos_integer()) -> {ok, [pid()]} | {error, term()}.
+start_pool(Pool, Size) ->
+    start_pool(Pool, Size, auto).
+
+%% @doc Start a named pool with given size and mode.
+%%
+%% @param Pool Pool name (default, io, or custom)
+%% @param Size Number of contexts in the pool
+%% @param Mode Context mode (auto, subinterp, worker)
+%% @returns {ok, [Context]} | {error, Reason}
+-spec start_pool(pool_name(), pos_integer(), py_context:context_mode()) ->
+    {ok, [pid()]} | {error, term()}.
+start_pool(Pool, Size, Mode) when is_atom(Pool), is_integer(Size), Size > 0 ->
+    %% Check if pool already exists
+    case persistent_term:get(?POOL_CONTEXTS_KEY(Pool), undefined) of
+        undefined ->
+            do_start_pool(Pool, Size, Mode);
         Contexts when is_list(Contexts) ->
             %% Verify at least one context is still alive
             case lists:any(fun is_process_alive/1, Contexts) of
@@ -123,17 +284,14 @@ start(Opts) ->
                     {ok, Contexts};
                 false ->
                     %% All dead - restart
-                    stop(),  %% Clean up stale entries
-                    do_start(Opts)
+                    stop_pool(Pool),
+                    do_start_pool(Pool, Size, Mode)
             end
     end.
 
 %% @private
-do_start(Opts) ->
-    NumContexts = maps:get(contexts, Opts, erlang:system_info(schedulers)),
-    Mode = maps:get(mode, Opts, auto),
-
-    %% Start the supervisor if not already running
+do_start_pool(Pool, Size, Mode) ->
+    %% Ensure supervisor is running
     case whereis(py_context_sup) of
         undefined ->
             case py_context_sup:start_link() of
@@ -145,40 +303,42 @@ do_start(Opts) ->
             ok
     end,
 
-    %% Start contexts
+    %% Start contexts for this pool
     try
         Contexts = lists:map(
             fun(N) ->
-                case py_context_sup:start_context(N, Mode) of
+                %% Use pool-unique ID: {Pool, N}
+                Id = {Pool, N},
+                case py_context_sup:start_context(Id, Mode) of
                     {ok, Pid} ->
-                        persistent_term:put(?CONTEXT_KEY(N), Pid),
+                        persistent_term:put(?POOL_CONTEXT_KEY(Pool, N), Pid),
                         Pid;
                     {error, Reason} ->
-                        throw({context_start_failed, N, Reason})
+                        throw({context_start_failed, Pool, N, Reason})
                 end
             end,
-            lists:seq(1, NumContexts)
+            lists:seq(1, Size)
         ),
 
-        %% Store metadata
-        persistent_term:put(?NUM_CONTEXTS_KEY, NumContexts),
-        persistent_term:put(?CONTEXTS_KEY, Contexts),
+        %% Store pool metadata
+        persistent_term:put(?POOL_SIZE_KEY(Pool), Size),
+        persistent_term:put(?POOL_CONTEXTS_KEY(Pool), Contexts),
 
         {ok, Contexts}
     catch
         throw:Err ->
-            %% Clean up any contexts that were started
-            stop(),
+            stop_pool(Pool),
             {error, Err}
     end.
 
-%% @doc Stop the context router.
+%% @doc Stop a named pool.
 %%
-%% Stops all contexts and removes persistent_term entries.
--spec stop() -> ok.
-stop() ->
-    %% Stop all contexts
-    case persistent_term:get(?CONTEXTS_KEY, undefined) of
+%% @param Pool Pool name to stop
+%% @returns ok
+-spec stop_pool(pool_name()) -> ok.
+stop_pool(Pool) when is_atom(Pool) ->
+    %% Stop all contexts in the pool
+    case persistent_term:get(?POOL_CONTEXTS_KEY(Pool), undefined) of
         undefined ->
             ok;
         Contexts ->
@@ -190,90 +350,157 @@ stop() ->
             )
     end,
 
-    %% Clean up persistent terms
-    NumContexts = persistent_term:get(?NUM_CONTEXTS_KEY, 0),
+    %% Clean up persistent terms for this pool
+    Size = persistent_term:get(?POOL_SIZE_KEY(Pool), 0),
     lists:foreach(
         fun(N) ->
-            catch persistent_term:erase(?CONTEXT_KEY(N))
+            catch persistent_term:erase(?POOL_CONTEXT_KEY(Pool, N))
         end,
-        lists:seq(1, NumContexts)
+        lists:seq(1, Size)
     ),
-    catch persistent_term:erase(?NUM_CONTEXTS_KEY),
-    catch persistent_term:erase(?CONTEXTS_KEY),
+    catch persistent_term:erase(?POOL_SIZE_KEY(Pool)),
+    catch persistent_term:erase(?POOL_CONTEXTS_KEY(Pool)),
     ok.
 
-%% @doc Check if contexts have been started and are still alive.
+%% @doc Check if a pool has been started and is still alive.
 %%
-%% @returns true if contexts are running, false otherwise
--spec is_started() -> boolean().
-is_started() ->
-    case persistent_term:get(?NUM_CONTEXTS_KEY, 0) of
+%% @param Pool Pool name to check
+%% @returns true if pool is running, false otherwise
+-spec pool_started(pool_name()) -> boolean().
+pool_started(Pool) when is_atom(Pool) ->
+    case persistent_term:get(?POOL_SIZE_KEY(Pool), 0) of
         0 -> false;
         _N ->
             %% Verify at least one context is actually alive
-            %% (persistent_term may have stale data after app restart)
-            case persistent_term:get(?CONTEXT_KEY(1), undefined) of
+            case persistent_term:get(?POOL_CONTEXT_KEY(Pool, 1), undefined) of
                 undefined -> false;
                 Pid when is_pid(Pid) -> is_process_alive(Pid);
                 _ -> false
             end
     end.
 
-%% @doc Get the context for the current process.
+%% ============================================================================
+%% Pool Registration (route module/func to specific pools)
+%% ============================================================================
+
+%% @doc Initialize the pool registry.
 %%
-%% If the process has a bound context, returns that context.
-%% Otherwise, selects a context based on the current scheduler ID.
-%%
-%% @returns Context pid
--spec get_context() -> pid().
-get_context() ->
-    case get(?BOUND_CONTEXT_KEY) of
+%% This is called automatically on first registration.
+%% Safe to call multiple times - does nothing if already initialized.
+-spec init_pool_registry() -> ok.
+init_pool_registry() ->
+    case persistent_term:get(?POOL_REGISTRY_KEY, undefined) of
         undefined ->
-            select_by_scheduler();
-        Ctx ->
-            Ctx
+            persistent_term:put(?POOL_REGISTRY_KEY, #{}),
+            ok;
+        _ ->
+            ok
     end.
 
-%% @doc Get a specific context by index.
+%% @doc Register a module to use a specific pool for all functions.
 %%
-%% @param N Context index (1 to num_contexts)
-%% @returns Context pid
--spec get_context(pos_integer()) -> pid().
-get_context(N) when is_integer(N), N > 0 ->
-    persistent_term:get(?CONTEXT_KEY(N)).
-
-%% @doc Bind a context to the current process.
+%% All calls to `Module:*' will be routed to the specified pool.
 %%
-%% After binding, `get_context/0' will always return this context
-%% instead of selecting by scheduler.
+%% Example:
+%% ```
+%% %% Route all 'requests' module calls to io pool
+%% py_context_router:register_pool(io, requests).
+%% '''
 %%
-%% @param Ctx Context pid to bind
+%% @param Pool Pool name to route to
+%% @param Module Python module name
 %% @returns ok
--spec bind_context(pid()) -> ok.
-bind_context(Ctx) when is_pid(Ctx) ->
-    put(?BOUND_CONTEXT_KEY, Ctx),
+-spec register_pool(pool_name(), atom()) -> ok.
+register_pool(Pool, Module) when is_atom(Pool), is_atom(Module) ->
+    Registry = get_registry(),
+    NewRegistry = maps:put({Module, '_'}, Pool, Registry),
+    persistent_term:put(?POOL_REGISTRY_KEY, NewRegistry),
     ok.
 
-%% @doc Unbind the current process's context.
+%% @doc Register a specific module/function to use a specific pool.
 %%
-%% After unbinding, `get_context/0' will return to scheduler-based
-%% selection.
+%% Calls to `Module:Func' will be routed to the specified pool.
+%% More specific registrations (module+func) take precedence over
+%% module-only registrations.
 %%
+%% Example:
+%% ```
+%% %% Route requests.get to io pool
+%% py_context_router:register_pool(io, requests, get).
+%% '''
+%%
+%% @param Pool Pool name to route to
+%% @param Module Python module name
+%% @param Func Python function name
 %% @returns ok
--spec unbind_context() -> ok.
-unbind_context() ->
-    erase(?BOUND_CONTEXT_KEY),
+-spec register_pool(pool_name(), atom(), atom()) -> ok.
+register_pool(Pool, Module, Func) when is_atom(Pool), is_atom(Module), is_atom(Func) ->
+    Registry = get_registry(),
+    NewRegistry = maps:put({Module, Func}, Pool, Registry),
+    persistent_term:put(?POOL_REGISTRY_KEY, NewRegistry),
     ok.
 
-%% @doc Get the number of contexts.
--spec num_contexts() -> non_neg_integer().
-num_contexts() ->
-    persistent_term:get(?NUM_CONTEXTS_KEY, 0).
+%% @doc Unregister a module from pool routing.
+%%
+%% Calls will return to using the default pool.
+%%
+%% @param Module Python module name
+%% @returns ok
+-spec unregister_pool(atom()) -> ok.
+unregister_pool(Module) when is_atom(Module) ->
+    Registry = get_registry(),
+    NewRegistry = maps:remove({Module, '_'}, Registry),
+    persistent_term:put(?POOL_REGISTRY_KEY, NewRegistry),
+    ok.
 
-%% @doc Get all context pids.
--spec contexts() -> [pid()].
-contexts() ->
-    persistent_term:get(?CONTEXTS_KEY, []).
+%% @doc Unregister a specific module/function from pool routing.
+%%
+%% @param Module Python module name
+%% @param Func Python function name
+%% @returns ok
+-spec unregister_pool(atom(), atom()) -> ok.
+unregister_pool(Module, Func) when is_atom(Module), is_atom(Func) ->
+    Registry = get_registry(),
+    NewRegistry = maps:remove({Module, Func}, Registry),
+    persistent_term:put(?POOL_REGISTRY_KEY, NewRegistry),
+    ok.
+
+%% @doc Look up which pool a module/function is registered to.
+%%
+%% First checks for a specific module+func registration.
+%% If not found, checks for a module-only registration.
+%% Returns `default' if no registration found.
+%%
+%% @param Module Python module name
+%% @param Func Python function name
+%% @returns Pool name
+-spec lookup_pool(atom(), atom()) -> pool_name().
+lookup_pool(Module, Func) when is_atom(Module), is_atom(Func) ->
+    Registry = get_registry(),
+    %% First try specific module+func, then module-only, then default
+    case maps:get({Module, Func}, Registry, undefined) of
+        undefined ->
+            case maps:get({Module, '_'}, Registry, undefined) of
+                undefined -> ?DEFAULT_POOL;
+                Pool -> Pool
+            end;
+        Pool ->
+            Pool
+    end.
+
+%% @doc List all pool registrations.
+%%
+%% Returns a list of `{{Module, Func}, Pool}' tuples.
+%% @returns List of registrations
+-spec list_pool_registrations() -> [{{atom(), atom() | '_'}, pool_name()}].
+list_pool_registrations() ->
+    maps:to_list(get_registry()).
+
+%% @private
+%% Get the pool registry map from persistent_term
+-spec get_registry() -> #{}.
+get_registry() ->
+    persistent_term:get(?POOL_REGISTRY_KEY, #{}).
 
 %% ============================================================================
 %% Internal functions
@@ -281,9 +508,9 @@ contexts() ->
 
 %% @private
 %% Select context based on scheduler ID using modulo
--spec select_by_scheduler() -> pid().
-select_by_scheduler() ->
+-spec select_by_scheduler(pool_name()) -> pid().
+select_by_scheduler(Pool) ->
     SchedId = erlang:system_info(scheduler_id),
-    NumCtx = persistent_term:get(?NUM_CONTEXTS_KEY),
+    NumCtx = persistent_term:get(?POOL_SIZE_KEY(Pool)),
     Idx = ((SchedId - 1) rem NumCtx) + 1,
-    persistent_term:get(?CONTEXT_KEY(Idx)).
+    persistent_term:get(?POOL_CONTEXT_KEY(Pool, Idx)).

--- a/src/py_context_sup.erl
+++ b/src/py_context_sup.erl
@@ -43,10 +43,10 @@ start_link() ->
 
 %% @doc Start a new py_context under this supervisor.
 %%
-%% @param Id Unique identifier for the context
+%% @param Id Unique identifier for the context (integer or {Pool, N} tuple)
 %% @param Mode Context mode (auto | subinterp | worker)
 %% @returns {ok, Pid} | {error, Reason}
--spec start_context(pos_integer(), py_context:context_mode()) ->
+-spec start_context(term(), py_context:context_mode()) ->
     {ok, pid()} | {error, term()}.
 start_context(Id, Mode) ->
     supervisor:start_child(?MODULE, [Id, Mode]).

--- a/test/py_pool_SUITE.erl
+++ b/test/py_pool_SUITE.erl
@@ -1,0 +1,287 @@
+%%% @doc Common Test suite for dual pool support.
+%%%
+%%% Tests the default and io pool separation to ensure:
+%%% - Pools are independent
+%%% - Pool-based calls work correctly
+%%% - Backward compatibility is maintained
+%%% - I/O operations don't block CPU operations
+-module(py_pool_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-export([
+    all/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    test_pools_started/1,
+    test_default_pool_call/1,
+    test_io_pool_call/1,
+    test_pool_isolation/1,
+    test_backward_compatibility/1,
+    test_pool_call_with_kwargs/1,
+    test_io_doesnt_block_default/1,
+    test_explicit_context_call/1,
+    test_pool_sizes/1,
+    %% Registration tests
+    test_register_module_to_pool/1,
+    test_register_function_to_pool/1,
+    test_unregister_pool/1,
+    test_registration_priority/1
+]).
+
+%% ============================================================================
+%% Common Test callbacks
+%% ============================================================================
+
+all() ->
+    [
+        test_pools_started,
+        test_default_pool_call,
+        test_io_pool_call,
+        test_pool_isolation,
+        test_backward_compatibility,
+        test_pool_call_with_kwargs,
+        test_io_doesnt_block_default,
+        test_explicit_context_call,
+        test_pool_sizes,
+        %% Registration tests
+        test_register_module_to_pool,
+        test_register_function_to_pool,
+        test_unregister_pool,
+        test_registration_priority
+    ].
+
+init_per_suite(Config) ->
+    application:ensure_all_started(erlang_python),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    ok.
+
+%% ============================================================================
+%% Test cases
+%% ============================================================================
+
+%% @doc Verify both pools are started on application start.
+test_pools_started(_Config) ->
+    %% Default pool should be started
+    true = py_context_router:pool_started(default),
+    DefaultSize = py_context_router:num_contexts(default),
+    true = DefaultSize > 0,
+    ct:pal("Default pool size: ~p", [DefaultSize]),
+
+    %% IO pool should be started
+    true = py_context_router:pool_started(io),
+    IoSize = py_context_router:num_contexts(io),
+    true = IoSize > 0,
+    ct:pal("IO pool size: ~p", [IoSize]).
+
+%% @doc Test basic call on default pool.
+test_default_pool_call(_Config) ->
+    %% Implicit default pool (backward compatible)
+    {ok, 4.0} = py:call(math, sqrt, [16]),
+
+    %% Explicit default pool
+    {ok, 4.0} = py:call(default, math, sqrt, [16]).
+
+%% @doc Test basic call on io pool.
+test_io_pool_call(_Config) ->
+    %% Explicit io pool
+    {ok, 4.0} = py:call(io, math, sqrt, [16]),
+
+    %% Another call to verify consistency
+    {ok, 9.0} = py:call(io, math, sqrt, [81]).
+
+%% @doc Test that pools have separate contexts.
+test_pool_isolation(_Config) ->
+    %% Get context from each pool
+    DefaultCtx = py_context_router:get_context(default),
+    IoCtx = py_context_router:get_context(io),
+
+    %% They should be different processes
+    true = DefaultCtx =/= IoCtx,
+    ct:pal("Default context: ~p, IO context: ~p", [DefaultCtx, IoCtx]),
+
+    %% Both should be alive
+    true = is_process_alive(DefaultCtx),
+    true = is_process_alive(IoCtx).
+
+%% @doc Test backward compatibility - existing code should work unchanged.
+test_backward_compatibility(_Config) ->
+    %% py:call/3 should work
+    {ok, 4.0} = py:call(math, sqrt, [16]),
+
+    %% py:call/4 with kwargs should work
+    {ok, 8.0} = py:call(math, pow, [2, 3], #{}),
+
+    %% py:eval should work
+    {ok, 6} = py:eval(<<"2 + 4">>),
+
+    %% Context by index should work (legacy API)
+    Ctx1 = py_context_router:get_context(1),
+    true = is_pid(Ctx1).
+
+%% @doc Test pool calls with keyword arguments.
+test_pool_call_with_kwargs(_Config) ->
+    %% IO pool with kwargs
+    {ok, _} = py:call(io, json, dumps, [[1, 2, 3]], #{indent => 2}),
+
+    %% Default pool with kwargs (explicit)
+    {ok, _} = py:call(default, json, dumps, [[1, 2, 3]], #{}).
+
+%% @doc Test that slow I/O operations don't block the default pool.
+test_io_doesnt_block_default(_Config) ->
+    Parent = self(),
+
+    %% Start a slow operation on io pool
+    IoRef = spawn_monitor(fun() ->
+        %% Sleep for 500ms in io pool
+        py:call(io, time, sleep, [0.5]),
+        Parent ! {io_done, self()}
+    end),
+
+    %% Immediately start a quick operation on default pool
+    StartTime = erlang:monotonic_time(millisecond),
+    {ok, 4.0} = py:call(default, math, sqrt, [16]),
+    EndTime = erlang:monotonic_time(millisecond),
+
+    %% Default pool call should complete quickly (< 100ms)
+    %% not wait for the io pool sleep
+    Duration = EndTime - StartTime,
+    ct:pal("Default pool call duration: ~pms", [Duration]),
+    true = Duration < 100,
+
+    %% Wait for io operation to complete
+    receive
+        {io_done, _} -> ok
+    after 5000 ->
+        %% Clean up monitor
+        {_, MonRef} = IoRef,
+        erlang:demonitor(MonRef, [flush]),
+        ct:fail("IO operation timeout")
+    end.
+
+%% @doc Test using explicit context from a pool.
+test_explicit_context_call(_Config) ->
+    %% Get specific context from io pool
+    IoCtx = py_context_router:get_context(io),
+
+    %% Call using explicit context
+    {ok, 4.0} = py:call(IoCtx, math, sqrt, [16]),
+
+    %% Get specific context from default pool
+    DefaultCtx = py_context_router:get_context(default),
+    {ok, 9.0} = py:call(DefaultCtx, math, sqrt, [81]).
+
+%% @doc Verify pool sizes are correct.
+test_pool_sizes(_Config) ->
+    %% Default pool should be sized to schedulers (unless configured otherwise)
+    DefaultSize = py_context_router:num_contexts(default),
+    ExpectedDefault = erlang:system_info(schedulers),
+    ct:pal("Default pool: expected ~p, actual ~p", [ExpectedDefault, DefaultSize]),
+
+    %% IO pool should be 10 by default (from py_context_init)
+    IoSize = py_context_router:num_contexts(io),
+    ct:pal("IO pool size: ~p", [IoSize]),
+    true = IoSize > 0,
+
+    %% Verify we can list all contexts from each pool
+    DefaultContexts = py_context_router:contexts(default),
+    IoContexts = py_context_router:contexts(io),
+
+    DefaultSize = length(DefaultContexts),
+    IoSize = length(IoContexts),
+
+    %% All contexts should be alive
+    lists:foreach(fun(Ctx) ->
+        true = is_process_alive(Ctx)
+    end, DefaultContexts ++ IoContexts).
+
+%% ============================================================================
+%% Registration tests
+%% ============================================================================
+
+%% @doc Test registering a module to a pool routes all its functions.
+test_register_module_to_pool(_Config) ->
+    %% Register 'time' module to io pool
+    ok = py:register_pool(io, time),
+
+    %% Verify lookup returns io pool
+    io = py_context_router:lookup_pool(time, sleep),
+    io = py_context_router:lookup_pool(time, time),
+    io = py_context_router:lookup_pool(time, any_func),
+
+    %% Unregistered modules should still go to default
+    default = py_context_router:lookup_pool(math, sqrt),
+
+    %% Call should work and use io pool (we can't easily verify which pool
+    %% was used, but the call should succeed)
+    {ok, _} = py:call(time, time, []),
+
+    %% Cleanup
+    ok = py:unregister_pool(time).
+
+%% @doc Test registering a specific module/function to a pool.
+test_register_function_to_pool(_Config) ->
+    %% Register only json.loads to io pool
+    ok = py:register_pool(io, {json, loads}),
+
+    %% Verify lookup
+    io = py_context_router:lookup_pool(json, loads),
+    %% Other json functions should use default
+    default = py_context_router:lookup_pool(json, dumps),
+
+    %% Calls should work
+    {ok, #{<<"a">> := 1}} = py:call(json, loads, [<<"{\"a\": 1}">>]),
+    {ok, _} = py:call(json, dumps, [[1, 2, 3]]),
+
+    %% Cleanup
+    ok = py:unregister_pool({json, loads}).
+
+%% @doc Test unregistering returns to default pool.
+test_unregister_pool(_Config) ->
+    %% Register and verify
+    ok = py:register_pool(io, os),
+    io = py_context_router:lookup_pool(os, getcwd),
+
+    %% Unregister module
+    ok = py:unregister_pool(os),
+    default = py_context_router:lookup_pool(os, getcwd),
+
+    %% Register function and verify
+    ok = py:register_pool(io, {sys, path}),
+    io = py_context_router:lookup_pool(sys, path),
+
+    %% Unregister function
+    ok = py:unregister_pool({sys, path}),
+    default = py_context_router:lookup_pool(sys, path).
+
+%% @doc Test that function-specific registration takes priority over module.
+test_registration_priority(_Config) ->
+    %% Register entire json module to io pool
+    ok = py:register_pool(io, json),
+
+    %% Register json.dumps specifically to default pool
+    ok = py:register_pool(default, {json, dumps}),
+
+    %% json.dumps should use default (function-specific wins)
+    default = py_context_router:lookup_pool(json, dumps),
+    %% json.loads should use io (module registration)
+    io = py_context_router:lookup_pool(json, loads),
+    %% other json functions use io
+    io = py_context_router:lookup_pool(json, load),
+
+    %% Cleanup
+    ok = py:unregister_pool(json),
+    ok = py:unregister_pool({json, dumps}).


### PR DESCRIPTION
## Summary

- Two separate pools: `default` (CPU-bound) and `io` (I/O-bound, 10 contexts)
- Registration API for automatic routing without changing call sites
- `py:register_pool(io, Module)` routes all module calls to io pool
- `py:register_pool(io, {Module, Func})` routes specific callable
- persistent_term-based registry for fast lookups