### PR TITLE
Add erlang.schedule_inline() for inline continuations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Changelog
 
-## 2.2.0 (2026-03-13)
+## 2.2.0 (unreleased)
 
 ### Added
+
+- **Inline Continuation API** - High-performance scheduling without Erlang messaging
+  - `erlang.schedule_inline(module, func, args, kwargs)` - Chain Python calls via `enif_schedule_nif()`
+  - ~3x faster than `schedule_py` for tight loops (bypasses gen_server messaging)
+  - Captures caller's globals/locals for correct namespace resolution with subinterpreters
+  - `InlineScheduleMarker` type returned, must be returned from handler
+  - See [Scheduling API docs](docs/asyncio.md#explicit-scheduling-api)
+
+- **Inline Continuation Benchmark** - Performance comparison
+  - `bench_schedule_inline` in `examples/benchmark.erl`
+  - Compares `schedule_inline` vs `schedule_py` throughput
 
 - **Process-Bound Python Environments** - Each Erlang process gets an isolated Python namespace
   - `py:get_local_env/1` - Get or create a process-local Python environment

--- a/c_src/py_callback.c
+++ b/c_src/py_callback.c
@@ -1420,6 +1420,149 @@ static PyObject *py_schedule_py(PyObject *self, PyObject *args, PyObject *kwargs
     return (PyObject *)marker;
 }
 
+/* ============================================================================
+ * InlineScheduleMarker - marker type for inline continuation without messaging
+ *
+ * When a Python handler returns an InlineScheduleMarker, the NIF detects it
+ * and uses enif_schedule_nif() to continue execution directly, bypassing
+ * the Erlang messaging layer for better performance in tight loops.
+ *
+ * Note: InlineScheduleMarkerObject is forward declared in py_nif.c
+ * ============================================================================ */
+
+static void InlineScheduleMarker_dealloc(InlineScheduleMarkerObject *self) {
+    Py_XDECREF(self->module);
+    Py_XDECREF(self->func);
+    Py_XDECREF(self->args);
+    Py_XDECREF(self->kwargs);
+    Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+static PyObject *InlineScheduleMarker_repr(InlineScheduleMarkerObject *self) {
+    return PyUnicode_FromFormat("<erlang.InlineScheduleMarker module='%U' func='%U'>",
+                                 self->module, self->func);
+}
+
+static PyTypeObject InlineScheduleMarkerType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "erlang.InlineScheduleMarker",
+    .tp_doc = "Marker for inline continuation via enif_schedule_nif (no Erlang messaging)",
+    .tp_basicsize = sizeof(InlineScheduleMarkerObject),
+    .tp_itemsize = 0,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_dealloc = (destructor)InlineScheduleMarker_dealloc,
+    .tp_repr = (reprfunc)InlineScheduleMarker_repr,
+};
+
+/**
+ * Check if a Python object is an InlineScheduleMarker
+ */
+static int is_inline_schedule_marker(PyObject *obj) {
+    return Py_IS_TYPE(obj, &InlineScheduleMarkerType);
+}
+
+/**
+ * @brief Python: erlang.schedule_inline(module, func, args=None, kwargs=None) -> InlineScheduleMarker
+ *
+ * Creates an InlineScheduleMarker that, when returned from a handler function,
+ * causes the NIF to use enif_schedule_nif() to continue execution directly
+ * without going through Erlang messaging.
+ *
+ * This is more efficient than schedule_py() for tight loops that need to yield
+ * to the scheduler but don't need to interact with Erlang between calls.
+ *
+ * Flow comparison:
+ *   schedule_py: Python -> NIF -> Erlang message -> NIF -> Python
+ *   schedule_inline: Python -> NIF -> enif_schedule_nif -> NIF -> Python
+ *
+ * Usage:
+ *   def process_batch(data, offset=0, results=None):
+ *       if results is None:
+ *           results = []
+ *       chunk_end = min(offset + 100, len(data))
+ *       for i in range(offset, chunk_end):
+ *           results.append(transform(data[i]))
+ *       if chunk_end < len(data):
+ *           if erlang.consume_time_slice(25):
+ *               return erlang.schedule_inline('__main__', 'process_batch',
+ *                                             args=[data, chunk_end, results])
+ *           return process_batch(data, chunk_end, results)
+ *       return results
+ *
+ * @param self Module reference (unused)
+ * @param args Positional args: (module, func)
+ * @param kwargs Keyword args: args=list/tuple, kwargs=dict
+ * @return InlineScheduleMarker object or NULL with exception
+ */
+static PyObject *py_schedule_inline(PyObject *self, PyObject *args, PyObject *kwargs) {
+    (void)self;
+
+    static char *kwlist[] = {"module", "func", "args", "kwargs", NULL};
+    PyObject *module_name = NULL;
+    PyObject *func_name = NULL;
+    PyObject *call_args = Py_None;
+    PyObject *call_kwargs = Py_None;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|OO", kwlist,
+            &module_name, &func_name, &call_args, &call_kwargs)) {
+        return NULL;
+    }
+
+    /* Validate module and func are strings */
+    if (!PyUnicode_Check(module_name)) {
+        PyErr_SetString(PyExc_TypeError, "module must be a string");
+        return NULL;
+    }
+    if (!PyUnicode_Check(func_name)) {
+        PyErr_SetString(PyExc_TypeError, "func must be a string");
+        return NULL;
+    }
+
+    /* Validate args is None or a sequence */
+    if (call_args != Py_None && !PyTuple_Check(call_args) && !PyList_Check(call_args)) {
+        PyErr_SetString(PyExc_TypeError, "args must be None, a tuple, or a list");
+        return NULL;
+    }
+
+    /* Validate kwargs is None or a dict */
+    if (call_kwargs != Py_None && !PyDict_Check(call_kwargs)) {
+        PyErr_SetString(PyExc_TypeError, "kwargs must be None or a dict");
+        return NULL;
+    }
+
+    /* Create the marker */
+    InlineScheduleMarkerObject *marker = PyObject_New(InlineScheduleMarkerObject, &InlineScheduleMarkerType);
+    if (marker == NULL) {
+        return NULL;
+    }
+
+    Py_INCREF(module_name);
+    marker->module = module_name;
+
+    Py_INCREF(func_name);
+    marker->func = func_name;
+
+    /* Convert args to tuple if it's a list */
+    if (call_args == Py_None) {
+        Py_INCREF(Py_None);
+        marker->args = Py_None;
+    } else if (PyList_Check(call_args)) {
+        marker->args = PyList_AsTuple(call_args);
+        if (marker->args == NULL) {
+            Py_DECREF(marker);
+            return NULL;
+        }
+    } else {
+        Py_INCREF(call_args);
+        marker->args = call_args;
+    }
+
+    Py_INCREF(call_kwargs);
+    marker->kwargs = call_kwargs;
+
+    return (PyObject *)marker;
+}
+
 /**
  * @brief Python: erlang.consume_time_slice(percent) -> bool
  *
@@ -2484,6 +2627,10 @@ static PyMethodDef ErlangModuleMethods[] = {
      "Schedule Python function continuation (must be returned from handler).\n\n"
      "Usage: return erlang.schedule_py('module', 'func', [args], {'kwargs'})\n"
      "Releases dirty scheduler and continues via _execute_py callback."},
+    {"schedule_inline", (PyCFunction)py_schedule_inline, METH_VARARGS | METH_KEYWORDS,
+     "Schedule inline Python continuation via enif_schedule_nif (no Erlang messaging).\n\n"
+     "Usage: return erlang.schedule_inline('module', 'func', args=[...], kwargs={...})\n"
+     "More efficient than schedule_py for tight loops that don't need Erlang interaction."},
     {"consume_time_slice", py_consume_time_slice, METH_VARARGS,
      "Check/consume NIF time slice for cooperative scheduling.\n\n"
      "Usage: if erlang.consume_time_slice(percent): return erlang.schedule_py(...)\n"
@@ -2587,6 +2734,11 @@ static int create_erlang_module(void) {
         return -1;
     }
 
+    /* Initialize InlineScheduleMarker type */
+    if (PyType_Ready(&InlineScheduleMarkerType) < 0) {
+        return -1;
+    }
+
     PyObject *module = PyModule_Create(&ErlangModuleDef);
     if (module == NULL) {
         return -1;
@@ -2642,6 +2794,14 @@ static int create_erlang_module(void) {
     Py_INCREF(&ScheduleMarkerType);
     if (PyModule_AddObject(module, "ScheduleMarker", (PyObject *)&ScheduleMarkerType) < 0) {
         Py_DECREF(&ScheduleMarkerType);
+        Py_DECREF(module);
+        return -1;
+    }
+
+    /* Add InlineScheduleMarker type to module */
+    Py_INCREF(&InlineScheduleMarkerType);
+    if (PyModule_AddObject(module, "InlineScheduleMarker", (PyObject *)&InlineScheduleMarkerType) < 0) {
+        Py_DECREF(&InlineScheduleMarkerType);
         Py_DECREF(module);
         return -1;
     }

--- a/c_src/py_callback.c
+++ b/c_src/py_callback.c
@@ -1435,6 +1435,8 @@ static void InlineScheduleMarker_dealloc(InlineScheduleMarkerObject *self) {
     Py_XDECREF(self->func);
     Py_XDECREF(self->args);
     Py_XDECREF(self->kwargs);
+    Py_XDECREF(self->globals);
+    Py_XDECREF(self->locals);
     Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
@@ -1559,6 +1561,22 @@ static PyObject *py_schedule_inline(PyObject *self, PyObject *args, PyObject *kw
 
     Py_INCREF(call_kwargs);
     marker->kwargs = call_kwargs;
+
+    /* Capture globals and locals from caller's frame */
+    PyObject *frame_globals = PyEval_GetGlobals();  /* Borrowed reference */
+    PyObject *frame_locals = PyEval_GetLocals();    /* Borrowed reference */
+    if (frame_globals != NULL) {
+        Py_INCREF(frame_globals);
+        marker->globals = frame_globals;
+    } else {
+        marker->globals = NULL;
+    }
+    if (frame_locals != NULL) {
+        Py_INCREF(frame_locals);
+        marker->locals = frame_locals;
+    } else {
+        marker->locals = NULL;
+    }
 
     return (PyObject *)marker;
 }

--- a/c_src/py_exec.c
+++ b/c_src/py_exec.c
@@ -329,6 +329,13 @@ static void process_request(py_request_t *req) {
                 req->result = enif_make_tuple2(env, ATOM_OK,
                     enif_make_tuple2(env, ATOM_GENERATOR, gen_ref));
             }
+        } else if (is_inline_schedule_marker(py_result)) {
+            /* Inline schedule marker not supported in legacy worker NIFs.
+             * Note: py:call() uses the context API (nif_context_call), which
+             * does support schedule_inline. This code path is only hit by
+             * direct py_nif:worker_call usage, which is rare. */
+            Py_DECREF(py_result);
+            req->result = make_error(env, "schedule_inline_not_supported_in_worker_mode");
         } else if (is_schedule_marker(py_result)) {
             /* Schedule marker: release dirty scheduler, continue via callback */
             ScheduleMarkerObject *marker = (ScheduleMarkerObject *)py_result;
@@ -424,6 +431,11 @@ static void process_request(py_request_t *req) {
                     req->result = enif_make_tuple2(env, ATOM_OK,
                         enif_make_tuple2(env, ATOM_GENERATOR, gen_ref));
                 }
+            } else if (is_inline_schedule_marker(py_result)) {
+                /* Inline schedule marker not supported in legacy worker NIFs.
+                 * Note: py:call() uses the context API, which supports schedule_inline. */
+                Py_DECREF(py_result);
+                req->result = make_error(env, "schedule_inline_not_supported_in_worker_mode");
             } else if (is_schedule_marker(py_result)) {
                 /* Schedule marker: release dirty scheduler, continue via callback */
                 ScheduleMarkerObject *marker = (ScheduleMarkerObject *)py_result;

--- a/c_src/py_nif.c
+++ b/c_src/py_nif.c
@@ -63,6 +63,9 @@ ErlNifResourceType *PY_REF_RESOURCE_TYPE = NULL;
 /* suspended_context_state_t resource type (context suspension for callbacks) */
 ErlNifResourceType *PY_CONTEXT_SUSPENDED_RESOURCE_TYPE = NULL;
 
+/* inline_continuation_t resource type (inline scheduler continuation) */
+ErlNifResourceType *INLINE_CONTINUATION_RESOURCE_TYPE = NULL;
+
 /* Process-local Python environment resource type */
 ErlNifResourceType *PY_ENV_RESOURCE_TYPE = NULL;
 
@@ -267,6 +270,16 @@ typedef struct {
     PyObject *args;           /* Arguments (tuple) */
 } ScheduleMarkerObject;
 static int is_schedule_marker(PyObject *obj);
+
+/* Inline schedule marker type and helper - from py_callback.c, needed by py_exec.c */
+typedef struct {
+    PyObject_HEAD
+    PyObject *module;      /* Module name (string) */
+    PyObject *func;        /* Function name (string) */
+    PyObject *args;        /* Arguments (tuple or None) */
+    PyObject *kwargs;      /* Keyword arguments (dict or None) */
+} InlineScheduleMarkerObject;
+static int is_inline_schedule_marker(PyObject *obj);
 
 /* ============================================================================
  * Include module implementations
@@ -628,6 +641,355 @@ static void suspended_state_destructor(ErlNifEnv *env, void *obj) {
     pthread_cond_destroy(&state->cond);
 
     atomic_fetch_add(&g_counters.suspended_destroyed, 1);
+}
+
+/* ============================================================================
+ * Inline Continuation Support
+ * ============================================================================
+ *
+ * Inline continuations allow Python functions to chain directly via
+ * enif_schedule_nif() without returning to Erlang messaging.
+ */
+
+/**
+ * @brief Destructor for inline_continuation_t resource
+ *
+ * Frees all resources associated with an inline continuation.
+ */
+static void inline_continuation_destructor(ErlNifEnv *env, void *obj) {
+    (void)env;
+    inline_continuation_t *cont = (inline_continuation_t *)obj;
+
+    /* Free string allocations */
+    if (cont->module_name != NULL) {
+        enif_free(cont->module_name);
+        cont->module_name = NULL;
+    }
+    if (cont->func_name != NULL) {
+        enif_free(cont->func_name);
+        cont->func_name = NULL;
+    }
+
+    /* Clean up Python objects if Python is still initialized */
+    if (runtime_is_running() && (cont->args != NULL || cont->kwargs != NULL)) {
+        /* For subinterpreter contexts: defer cleanup to Py_EndInterpreter */
+#ifdef HAVE_SUBINTERPRETERS
+        if (cont->ctx != NULL && cont->ctx->is_subinterp) {
+            cont->args = NULL;
+            cont->kwargs = NULL;
+        } else
+#endif
+        {
+            /* Main interpreter: safe to use PyGILState_Ensure */
+            if (PyGILState_GetThisThreadState() == NULL && !PyGILState_Check()) {
+                PyGILState_STATE gstate = PyGILState_Ensure();
+                Py_XDECREF(cont->args);
+                Py_XDECREF(cont->kwargs);
+                cont->args = NULL;
+                cont->kwargs = NULL;
+                PyGILState_Release(gstate);
+            } else {
+                cont->args = NULL;
+                cont->kwargs = NULL;
+            }
+        }
+    }
+
+    /* Release the context resource if held */
+    if (cont->ctx != NULL) {
+        enif_release_resource(cont->ctx);
+        cont->ctx = NULL;
+    }
+
+    /* Release the local_env resource if held */
+    if (cont->local_env != NULL) {
+        enif_release_resource(cont->local_env);
+        cont->local_env = NULL;
+    }
+}
+
+/**
+ * @brief Create an inline continuation resource
+ *
+ * @param ctx Context for execution (will be kept)
+ * @param local_env Optional process-local environment (will be kept if non-NULL)
+ * @param marker The InlineScheduleMarker containing call info
+ * @param depth Current continuation depth
+ * @return inline_continuation_t* or NULL on failure
+ *
+ * @note Caller must release the resource when done
+ */
+static inline_continuation_t *create_inline_continuation(
+    py_context_t *ctx,
+    void *local_env,  /* py_env_resource_t* */
+    PyObject *marker_obj,
+    uint32_t depth) {
+
+    InlineScheduleMarkerObject *marker = (InlineScheduleMarkerObject *)marker_obj;
+
+    inline_continuation_t *cont = enif_alloc_resource(
+        INLINE_CONTINUATION_RESOURCE_TYPE, sizeof(inline_continuation_t));
+    if (cont == NULL) {
+        return NULL;
+    }
+
+    memset(cont, 0, sizeof(inline_continuation_t));
+
+    /* Copy module name */
+    Py_ssize_t module_len;
+    const char *module_str = PyUnicode_AsUTF8AndSize(marker->module, &module_len);
+    if (module_str == NULL) {
+        enif_release_resource(cont);
+        return NULL;
+    }
+    cont->module_name = enif_alloc(module_len + 1);
+    if (cont->module_name == NULL) {
+        enif_release_resource(cont);
+        return NULL;
+    }
+    memcpy(cont->module_name, module_str, module_len);
+    cont->module_name[module_len] = '\0';
+    cont->module_len = module_len;
+
+    /* Copy func name */
+    Py_ssize_t func_len;
+    const char *func_str = PyUnicode_AsUTF8AndSize(marker->func, &func_len);
+    if (func_str == NULL) {
+        enif_release_resource(cont);
+        return NULL;
+    }
+    cont->func_name = enif_alloc(func_len + 1);
+    if (cont->func_name == NULL) {
+        enif_release_resource(cont);
+        return NULL;
+    }
+    memcpy(cont->func_name, func_str, func_len);
+    cont->func_name[func_len] = '\0';
+    cont->func_len = func_len;
+
+    /* INCREF args and kwargs */
+    if (marker->args != Py_None) {
+        Py_INCREF(marker->args);
+        cont->args = marker->args;
+    } else {
+        cont->args = NULL;
+    }
+    if (marker->kwargs != Py_None) {
+        Py_INCREF(marker->kwargs);
+        cont->kwargs = marker->kwargs;
+    } else {
+        cont->kwargs = NULL;
+    }
+
+    /* Store context (keep resource reference) */
+    cont->ctx = ctx;
+    enif_keep_resource(ctx);
+
+    /* Store local_env if provided */
+    if (local_env != NULL) {
+        cont->local_env = local_env;
+        enif_keep_resource(local_env);
+    }
+
+    cont->depth = depth;
+    cont->interp_id = ctx->interp_id;
+
+    return cont;
+}
+
+/**
+ * @brief NIF: Execute inline continuation
+ *
+ * This is the continuation function called by enif_schedule_nif().
+ * It executes the Python function and handles the result:
+ * - InlineScheduleMarker: chain via another enif_schedule_nif
+ * - ScheduleMarker: return {schedule, ...} to Erlang
+ * - Suspension: return {suspended, ...} to Erlang
+ * - Normal result: return {ok, Result}
+ */
+static ERL_NIF_TERM nif_inline_continuation(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    (void)argc;
+
+    inline_continuation_t *cont;
+    if (!enif_get_resource(env, argv[0], INLINE_CONTINUATION_RESOURCE_TYPE, (void **)&cont)) {
+        return make_error(env, "invalid_continuation");
+    }
+
+    if (!runtime_is_running()) {
+        return make_error(env, "python_not_running");
+    }
+
+    /* Check depth limit */
+    if (cont->depth >= MAX_INLINE_CONTINUATION_DEPTH) {
+        return make_error(env, "inline_continuation_depth_exceeded");
+    }
+
+    py_context_t *ctx = cont->ctx;
+    if (ctx == NULL || ctx->destroyed) {
+        return make_error(env, "context_destroyed");
+    }
+
+    /* Acquire thread state */
+    py_context_guard_t guard = py_context_acquire(ctx);
+    if (!guard.acquired) {
+        return make_error(env, "acquire_failed");
+    }
+
+    /* Set thread-local context for callback support */
+    py_context_t *prev_context = tl_current_context;
+    tl_current_context = ctx;
+
+    /* Enable suspension for callback support */
+    bool prev_allow_suspension = tl_allow_suspension;
+    tl_allow_suspension = true;
+
+    /* Set callback env for consume_time_slice */
+    ErlNifEnv *prev_callback_env = tl_callback_env;
+    tl_callback_env = env;
+
+    ERL_NIF_TERM result;
+
+    /* Import module and get function */
+    PyObject *func = NULL;
+    PyObject *module = NULL;
+
+    /* Use local_env globals if available for __main__, otherwise standard import */
+    py_env_resource_t *local_env = (py_env_resource_t *)cont->local_env;
+
+    if (strcmp(cont->module_name, "__main__") == 0) {
+        PyObject *globals = (local_env != NULL) ? local_env->globals : ctx->globals;
+        func = PyDict_GetItemString(globals, cont->func_name);
+        if (func == NULL) {
+            func = PyDict_GetItemString(ctx->locals, cont->func_name);
+        }
+        if (func != NULL) {
+            Py_INCREF(func);
+        } else {
+            PyErr_Format(PyExc_NameError, "name '%s' is not defined", cont->func_name);
+        }
+    } else {
+        module = PyImport_ImportModule(cont->module_name);
+        if (module != NULL) {
+            func = PyObject_GetAttrString(module, cont->func_name);
+            Py_DECREF(module);
+        }
+    }
+
+    if (func == NULL) {
+        result = make_py_error(env);
+        goto cleanup;
+    }
+
+    /* Build args tuple */
+    PyObject *args = cont->args;
+    if (args == NULL) {
+        args = PyTuple_New(0);
+        if (args == NULL) {
+            Py_DECREF(func);
+            result = make_py_error(env);
+            goto cleanup;
+        }
+    } else {
+        Py_INCREF(args);
+    }
+
+    /* Get kwargs */
+    PyObject *kwargs = cont->kwargs;
+
+    /* Call the function */
+    PyObject *py_result = PyObject_Call(func, args, kwargs);
+    Py_DECREF(func);
+    Py_DECREF(args);
+
+    if (py_result == NULL) {
+        /* Check for pending callback */
+        if (tl_pending_callback) {
+            PyErr_Clear();
+
+            /* Create suspended context state for callback handling */
+            ErlNifBinary module_bin, func_bin;
+            enif_alloc_binary(cont->module_len, &module_bin);
+            memcpy(module_bin.data, cont->module_name, cont->module_len);
+            enif_alloc_binary(cont->func_len, &func_bin);
+            memcpy(func_bin.data, cont->func_name, cont->func_len);
+
+            /* Convert args to Erlang term for replay */
+            ERL_NIF_TERM args_term = enif_make_list(env, 0);
+            if (cont->args != NULL) {
+                args_term = py_to_term(env, cont->args);
+            }
+
+            ERL_NIF_TERM kwargs_term = enif_make_new_map(env);
+            if (cont->kwargs != NULL) {
+                kwargs_term = py_to_term(env, cont->kwargs);
+            }
+
+            suspended_context_state_t *suspended = create_suspended_context_state_for_call(
+                env, ctx, &module_bin, &func_bin, args_term, kwargs_term);
+
+            enif_release_binary(&module_bin);
+            enif_release_binary(&func_bin);
+
+            if (suspended == NULL) {
+                tl_pending_callback = false;
+                Py_CLEAR(tl_pending_args);
+                result = make_error(env, "create_suspended_state_failed");
+            } else {
+                result = build_suspended_context_result(env, suspended);
+            }
+        } else {
+            result = make_py_error(env);
+        }
+    } else if (is_inline_schedule_marker(py_result)) {
+        /* Chain via another enif_schedule_nif */
+        inline_continuation_t *next_cont = create_inline_continuation(
+            ctx, cont->local_env, py_result, cont->depth + 1);
+        Py_DECREF(py_result);
+
+        if (next_cont == NULL) {
+            result = make_error(env, "create_continuation_failed");
+        } else {
+            ERL_NIF_TERM cont_ref = enif_make_resource(env, next_cont);
+            enif_release_resource(next_cont);
+
+            /* Restore thread-local state before scheduling */
+            tl_allow_suspension = prev_allow_suspension;
+            tl_current_context = prev_context;
+            tl_callback_env = prev_callback_env;
+            clear_pending_callback_tls();
+
+            py_context_release(&guard);
+
+            return enif_schedule_nif(env, "inline_continuation",
+                ERL_NIF_DIRTY_JOB_IO_BOUND, nif_inline_continuation, 1, &cont_ref);
+        }
+    } else if (is_schedule_marker(py_result)) {
+        /* Switch to schedule_py path */
+        ScheduleMarkerObject *marker = (ScheduleMarkerObject *)py_result;
+        ERL_NIF_TERM callback_name = py_to_term(env, marker->callback_name);
+        ERL_NIF_TERM callback_args = py_to_term(env, marker->args);
+        Py_DECREF(py_result);
+        result = enif_make_tuple3(env, ATOM_SCHEDULE, callback_name, callback_args);
+    } else {
+        /* Normal result */
+        ERL_NIF_TERM term_result = py_to_term(env, py_result);
+        Py_DECREF(py_result);
+        result = enif_make_tuple2(env, ATOM_OK, term_result);
+    }
+
+cleanup:
+    /* Restore thread-local state */
+    tl_allow_suspension = prev_allow_suspension;
+    tl_current_context = prev_context;
+    tl_callback_env = prev_callback_env;
+
+    /* Clear pending callback TLS */
+    clear_pending_callback_tls();
+
+    /* Release thread state */
+    py_context_release(&guard);
+
+    return result;
 }
 
 /* ============================================================================
@@ -2402,6 +2764,28 @@ static ERL_NIF_TERM nif_context_call(ErlNifEnv *env, int argc, const ERL_NIF_TER
         } else {
             result = make_py_error(env);
         }
+    } else if (is_inline_schedule_marker(py_result)) {
+        /* Inline schedule marker: chain via enif_schedule_nif without Erlang messaging */
+        inline_continuation_t *cont = create_inline_continuation(ctx, NULL, py_result, 0);
+        Py_DECREF(py_result);
+
+        if (cont == NULL) {
+            result = make_error(env, "create_continuation_failed");
+        } else {
+            ERL_NIF_TERM cont_ref = enif_make_resource(env, cont);
+            enif_release_resource(cont);
+
+            /* Restore thread-local state before scheduling */
+            tl_allow_suspension = prev_allow_suspension;
+            tl_current_context = prev_context;
+            clear_pending_callback_tls();
+            enif_free(module_name);
+            enif_free(func_name);
+            py_context_release(&guard);
+
+            return enif_schedule_nif(env, "inline_continuation",
+                ERL_NIF_DIRTY_JOB_IO_BOUND, nif_inline_continuation, 1, &cont_ref);
+        }
     } else if (is_schedule_marker(py_result)) {
         /* Schedule marker: release dirty scheduler, continue via callback */
         ScheduleMarkerObject *marker = (ScheduleMarkerObject *)py_result;
@@ -2514,6 +2898,27 @@ static ERL_NIF_TERM nif_context_eval(ErlNifEnv *env, int argc, const ERL_NIF_TER
             }
         } else {
             result = make_py_error(env);
+        }
+    } else if (is_inline_schedule_marker(py_result)) {
+        /* Inline schedule marker: chain via enif_schedule_nif without Erlang messaging */
+        inline_continuation_t *cont = create_inline_continuation(ctx, NULL, py_result, 0);
+        Py_DECREF(py_result);
+
+        if (cont == NULL) {
+            result = make_error(env, "create_continuation_failed");
+        } else {
+            ERL_NIF_TERM cont_ref = enif_make_resource(env, cont);
+            enif_release_resource(cont);
+
+            /* Restore thread-local state before scheduling */
+            tl_allow_suspension = prev_allow_suspension;
+            tl_current_context = prev_context;
+            clear_pending_callback_tls();
+            enif_free(code);
+            py_context_release(&guard);
+
+            return enif_schedule_nif(env, "inline_continuation",
+                ERL_NIF_DIRTY_JOB_IO_BOUND, nif_inline_continuation, 1, &cont_ref);
         }
     } else if (is_schedule_marker(py_result)) {
         /* Schedule marker: release dirty scheduler, continue via callback */
@@ -2887,6 +3292,28 @@ static ERL_NIF_TERM nif_context_eval_with_env(ErlNifEnv *env, int argc, const ER
         } else {
             result = make_py_error(env);
         }
+    } else if (is_inline_schedule_marker(py_result)) {
+        /* Inline schedule marker: chain via enif_schedule_nif with local_env */
+        inline_continuation_t *cont = create_inline_continuation(ctx, penv, py_result, 0);
+        Py_DECREF(py_result);
+
+        if (cont == NULL) {
+            result = make_error(env, "create_continuation_failed");
+        } else {
+            ERL_NIF_TERM cont_ref = enif_make_resource(env, cont);
+            enif_release_resource(cont);
+
+            /* Restore thread-local state before scheduling */
+            tl_allow_suspension = prev_allow_suspension;
+            tl_current_context = prev_context;
+            tl_current_local_env = prev_local_env;
+            clear_pending_callback_tls();
+            enif_free(code);
+            py_context_release(&guard);
+
+            return enif_schedule_nif(env, "inline_continuation",
+                ERL_NIF_DIRTY_JOB_IO_BOUND, nif_inline_continuation, 1, &cont_ref);
+        }
     } else if (is_schedule_marker(py_result)) {
         /* Schedule marker: release dirty scheduler, continue via callback */
         ScheduleMarkerObject *marker = (ScheduleMarkerObject *)py_result;
@@ -3056,6 +3483,29 @@ static ERL_NIF_TERM nif_context_call_with_env(ErlNifEnv *env, int argc, const ER
             }
         } else {
             result = make_py_error(env);
+        }
+    } else if (is_inline_schedule_marker(py_result)) {
+        /* Inline schedule marker: chain via enif_schedule_nif with local_env */
+        inline_continuation_t *cont = create_inline_continuation(ctx, penv, py_result, 0);
+        Py_DECREF(py_result);
+
+        if (cont == NULL) {
+            result = make_error(env, "create_continuation_failed");
+        } else {
+            ERL_NIF_TERM cont_ref = enif_make_resource(env, cont);
+            enif_release_resource(cont);
+
+            /* Restore thread-local state before scheduling */
+            tl_allow_suspension = prev_allow_suspension;
+            tl_current_context = prev_context;
+            tl_current_local_env = prev_local_env;
+            clear_pending_callback_tls();
+            enif_free(module_name);
+            enif_free(func_name);
+            py_context_release(&guard);
+
+            return enif_schedule_nif(env, "inline_continuation",
+                ERL_NIF_DIRTY_JOB_IO_BOUND, nif_inline_continuation, 1, &cont_ref);
         }
     } else if (is_schedule_marker(py_result)) {
         ScheduleMarkerObject *marker = (ScheduleMarkerObject *)py_result;
@@ -4224,11 +4674,17 @@ static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info) {
         env, NULL, "py_env", py_env_resource_dtor,
         ERL_NIF_RT_CREATE | ERL_NIF_RT_TAKEOVER, NULL);
 
+    /* Inline continuation resource type */
+    INLINE_CONTINUATION_RESOURCE_TYPE = enif_open_resource_type(
+        env, NULL, "inline_continuation", inline_continuation_destructor,
+        ERL_NIF_RT_CREATE | ERL_NIF_RT_TAKEOVER, NULL);
+
     if (WORKER_RESOURCE_TYPE == NULL || PYOBJ_RESOURCE_TYPE == NULL ||
         SUSPENDED_STATE_RESOURCE_TYPE == NULL ||
         PY_CONTEXT_RESOURCE_TYPE == NULL || PY_REF_RESOURCE_TYPE == NULL ||
         PY_CONTEXT_SUSPENDED_RESOURCE_TYPE == NULL ||
-        PY_ENV_RESOURCE_TYPE == NULL) {
+        PY_ENV_RESOURCE_TYPE == NULL ||
+        INLINE_CONTINUATION_RESOURCE_TYPE == NULL) {
         return -1;
     }
 #ifdef HAVE_SUBINTERPRETERS

--- a/c_src/py_nif.c
+++ b/c_src/py_nif.c
@@ -278,6 +278,8 @@ typedef struct {
     PyObject *func;        /* Function name (string) */
     PyObject *args;        /* Arguments (tuple or None) */
     PyObject *kwargs;      /* Keyword arguments (dict or None) */
+    PyObject *globals;     /* Captured globals from caller's frame */
+    PyObject *locals;      /* Captured locals from caller's frame */
 } InlineScheduleMarkerObject;
 static int is_inline_schedule_marker(PyObject *obj);
 
@@ -671,12 +673,15 @@ static void inline_continuation_destructor(ErlNifEnv *env, void *obj) {
     }
 
     /* Clean up Python objects if Python is still initialized */
-    if (runtime_is_running() && (cont->args != NULL || cont->kwargs != NULL)) {
+    if (runtime_is_running() && (cont->args != NULL || cont->kwargs != NULL ||
+                                  cont->globals != NULL || cont->locals != NULL)) {
         /* For subinterpreter contexts: defer cleanup to Py_EndInterpreter */
 #ifdef HAVE_SUBINTERPRETERS
         if (cont->ctx != NULL && cont->ctx->is_subinterp) {
             cont->args = NULL;
             cont->kwargs = NULL;
+            cont->globals = NULL;
+            cont->locals = NULL;
         } else
 #endif
         {
@@ -685,12 +690,18 @@ static void inline_continuation_destructor(ErlNifEnv *env, void *obj) {
                 PyGILState_STATE gstate = PyGILState_Ensure();
                 Py_XDECREF(cont->args);
                 Py_XDECREF(cont->kwargs);
+                Py_XDECREF(cont->globals);
+                Py_XDECREF(cont->locals);
                 cont->args = NULL;
                 cont->kwargs = NULL;
+                cont->globals = NULL;
+                cont->locals = NULL;
                 PyGILState_Release(gstate);
             } else {
                 cont->args = NULL;
                 cont->kwargs = NULL;
+                cont->globals = NULL;
+                cont->locals = NULL;
             }
         }
     }
@@ -781,6 +792,20 @@ static inline_continuation_t *create_inline_continuation(
         cont->kwargs = NULL;
     }
 
+    /* Store captured globals and locals */
+    if (marker->globals != NULL) {
+        Py_INCREF(marker->globals);
+        cont->globals = marker->globals;
+    } else {
+        cont->globals = NULL;
+    }
+    if (marker->locals != NULL) {
+        Py_INCREF(marker->locals);
+        cont->locals = marker->locals;
+    } else {
+        cont->locals = NULL;
+    }
+
     /* Store context (keep resource reference) */
     cont->ctx = ctx;
     enif_keep_resource(ctx);
@@ -853,12 +878,30 @@ static ERL_NIF_TERM nif_inline_continuation(ErlNifEnv *env, int argc, const ERL_
     PyObject *func = NULL;
     PyObject *module = NULL;
 
-    /* Use local_env globals if available for __main__, otherwise standard import */
+    /* Priority for __main__ lookups:
+     * 1. Captured globals/locals from the marker (caller's frame)
+     * 2. local_env globals (process-local environment)
+     * 3. ctx->globals/locals (context defaults)
+     */
     py_env_resource_t *local_env = (py_env_resource_t *)cont->local_env;
 
     if (strcmp(cont->module_name, "__main__") == 0) {
-        PyObject *globals = (local_env != NULL) ? local_env->globals : ctx->globals;
-        func = PyDict_GetItemString(globals, cont->func_name);
+        /* Try captured globals first (from caller's frame) */
+        if (cont->globals != NULL) {
+            func = PyDict_GetItemString(cont->globals, cont->func_name);
+        }
+        /* Try captured locals */
+        if (func == NULL && cont->locals != NULL) {
+            func = PyDict_GetItemString(cont->locals, cont->func_name);
+        }
+        /* Fallback to local_env globals */
+        if (func == NULL && local_env != NULL) {
+            func = PyDict_GetItemString(local_env->globals, cont->func_name);
+        }
+        /* Fallback to context globals/locals */
+        if (func == NULL) {
+            func = PyDict_GetItemString(ctx->globals, cont->func_name);
+        }
         if (func == NULL) {
             func = PyDict_GetItemString(ctx->locals, cont->func_name);
         }

--- a/c_src/py_nif.h
+++ b/c_src/py_nif.h
@@ -1106,6 +1106,12 @@ typedef struct {
     /** @brief Keyword arguments (Python dict or NULL, owned reference) */
     PyObject *kwargs;
 
+    /** @brief Captured globals from caller's frame (owned reference) */
+    PyObject *globals;
+
+    /** @brief Captured locals from caller's frame (owned reference) */
+    PyObject *locals;
+
     /** @brief Continuation depth (overflow protection) */
     uint32_t depth;
 

--- a/c_src/py_nif.h
+++ b/c_src/py_nif.h
@@ -1051,6 +1051,68 @@ typedef struct {
     } *callback_results;
 } suspended_context_state_t;
 
+/* ============================================================================
+ * Inline Continuation Support
+ * ============================================================================
+ *
+ * Inline continuations allow Python functions to chain directly via
+ * enif_schedule_nif() without returning to Erlang messaging. This provides
+ * significant performance improvements for tight loops that need to yield
+ * to the scheduler.
+ *
+ * Flow comparison:
+ *   schedule_py: Python -> ScheduleMarker -> NIF -> Erlang -> message -> NIF -> Python
+ *   schedule_inline: Python -> InlineScheduleMarker -> NIF -> enif_schedule_nif -> NIF -> Python
+ */
+
+/**
+ * @def MAX_INLINE_CONTINUATION_DEPTH
+ * @brief Maximum depth for chained inline continuations
+ *
+ * Prevents stack overflow from unbounded recursion. When this depth is
+ * exceeded, an error is returned to Erlang.
+ */
+#define MAX_INLINE_CONTINUATION_DEPTH 1000
+
+/**
+ * @struct inline_continuation_t
+ * @brief State for an inline scheduled continuation
+ *
+ * Captures all state needed to continue Python execution via
+ * enif_schedule_nif() without returning to Erlang messaging.
+ */
+typedef struct {
+    /** @brief Context for execution */
+    py_context_t *ctx;
+
+    /** @brief Process-local environment (may be NULL) */
+    void *local_env;  /* py_env_resource_t* - forward declared */
+
+    /** @brief Module name to call */
+    char *module_name;
+
+    /** @brief Length of module_name */
+    size_t module_len;
+
+    /** @brief Function name to call */
+    char *func_name;
+
+    /** @brief Length of func_name */
+    size_t func_len;
+
+    /** @brief Arguments (Python tuple, owned reference) */
+    PyObject *args;
+
+    /** @brief Keyword arguments (Python dict or NULL, owned reference) */
+    PyObject *kwargs;
+
+    /** @brief Continuation depth (overflow protection) */
+    uint32_t depth;
+
+    /** @brief Interpreter ID (subinterpreter support) */
+    uint32_t interp_id;
+} inline_continuation_t;
+
 /** @} */
 
 /* ============================================================================
@@ -1144,6 +1206,9 @@ extern ErlNifResourceType *PY_REF_RESOURCE_TYPE;
 
 /** @brief Resource type for suspended_context_state_t (context suspension) */
 extern ErlNifResourceType *PY_CONTEXT_SUSPENDED_RESOURCE_TYPE;
+
+/** @brief Resource type for inline_continuation_t (inline scheduler continuation) */
+extern ErlNifResourceType *INLINE_CONTINUATION_RESOURCE_TYPE;
 
 /** @brief Atomic counter for unique interpreter IDs */
 extern _Atomic uint32_t g_context_id_counter;

--- a/docs/asyncio.md
+++ b/docs/asyncio.md
@@ -1063,6 +1063,43 @@ This is useful for:
 - Allowing other Erlang processes to run
 - Cooperative multitasking
 
+#### erlang.schedule_inline(module, func, args=None, kwargs=None)
+
+Release the dirty scheduler and continue by calling a Python function via `enif_schedule_nif()` - bypassing Erlang messaging entirely.
+
+```python
+import erlang
+
+def process_chunk(data, offset=0, results=None):
+    """Process data in chunks with inline continuations."""
+    if results is None:
+        results = []
+
+    chunk_end = min(offset + 100, len(data))
+    for i in range(offset, chunk_end):
+        results.append(transform(data[i]))
+
+    if chunk_end < len(data):
+        # Continue inline - no Erlang messaging overhead
+        return erlang.schedule_inline(
+            '__main__', 'process_chunk',
+            args=[data, chunk_end, results]
+        )
+
+    return results
+```
+
+**When to use `schedule_inline` vs `schedule_py`:**
+
+| Aspect | `schedule_inline` | `schedule_py` |
+|--------|-------------------|---------------|
+| Flow | Python -> NIF -> enif_schedule_nif -> Python | Python -> NIF -> Erlang message -> Python |
+| Speed | ~3x faster for tight loops | Slower due to messaging |
+| Use case | Pure Python chains, no Erlang interaction | When you need Erlang messaging between steps |
+| Overhead | Minimal (direct NIF continuation) | Higher (gen_server call) |
+
+**Important:** `schedule_inline` captures the caller's globals/locals, ensuring correct namespace resolution even with subinterpreters.
+
 #### erlang.consume_time_slice(percent)
 
 Check if the NIF time slice is exhausted. Returns `True` if you should yield, `False` if more time remains.
@@ -1099,7 +1136,8 @@ def long_computation(items, start_idx=0):
 |---------|----------|-----------------|
 | `erlang.call()` | Quick operations or callbacks that use `receive` | Held (unless callback suspends via `receive`) |
 | `erlang.schedule()` | Need to call Erlang callback and always release scheduler | Released |
-| `erlang.schedule_py()` | Long Python computation, cooperative scheduling | Released |
+| `erlang.schedule_py()` | Long Python computation, need Erlang interaction between steps | Released |
+| `erlang.schedule_inline()` | Tight Python loops, no Erlang interaction needed (~3x faster) | Released |
 | `consume_time_slice()` | Fine-grained control over yielding | N/A (checks time slice) |
 
 ### Example: Cooperative Long-Running Task

--- a/examples/benchmark.erl
+++ b/examples/benchmark.erl
@@ -82,7 +82,8 @@ run_benchmarks(quick) ->
     bench_simple_call(100),
     bench_eval(100),
     bench_concurrent(10, 10),
-    bench_streaming(100);
+    bench_streaming(100),
+    bench_schedule_inline(20);
 
 run_benchmarks(full) ->
     io:format("Running full benchmarks...~n~n"),
@@ -92,7 +93,8 @@ run_benchmarks(full) ->
     bench_concurrent(1000, 10),
     bench_streaming(1000),
     bench_type_conversion(1000),
-    bench_semaphore(10000);
+    bench_semaphore(10000),
+    bench_schedule_inline(500);
 
 run_benchmarks(concurrent) ->
     io:format("Running concurrency benchmarks...~n~n"),
@@ -110,7 +112,8 @@ run_benchmarks(standard) ->
     bench_concurrent(50, 50),
     bench_streaming(500),
     bench_type_conversion(500),
-    bench_semaphore(5000).
+    bench_semaphore(5000),
+    bench_schedule_inline(100).
 
 %% Simple call benchmark
 bench_simple_call(N) ->
@@ -239,3 +242,74 @@ bench_semaphore(N) ->
     io:format("  Total time: ~.2f ms~n", [TimeMs]),
     io:format("  Per acquire/release: ~.4f ms~n", [PerOp]),
     io:format("  Throughput: ~p ops/sec~n~n", [round(OpsPerSec)]).
+
+%% Schedule inline vs schedule_py benchmark
+bench_schedule_inline(N) ->
+    io:format("Benchmark: schedule_inline vs schedule_py (chained calls)~n"),
+    io:format("  Iterations: ~p~n", [N]),
+
+    %% Set up test functions
+    Ctx = py:context(),
+    ok = py:exec(Ctx, <<"
+import __main__
+import erlang
+
+def increment(x):
+    return x + 1
+
+__main__.increment = increment
+
+# Chain using schedule_py (messaging overhead)
+def chain_schedule_py(x, count):
+    if count <= 0:
+        return x
+    x = erlang.schedule_py('__main__', 'increment', [x])
+    return erlang.schedule_py('__main__', 'chain_schedule_py', [x, count - 1])
+
+__main__.chain_schedule_py = chain_schedule_py
+
+# Chain using schedule_inline (no messaging)
+def chain_schedule_inline(x, count):
+    if count <= 0:
+        return x
+    x = increment(x)
+    return erlang.schedule_inline('__main__', 'chain_schedule_inline', [x, count - 1])
+
+__main__.chain_schedule_inline = chain_schedule_inline
+">>),
+
+    ChainLen = 10,
+
+    %% Benchmark schedule_py
+    {TimePy, _} = timer:tc(fun() ->
+        lists:foreach(fun(_) ->
+            {ok, _} = py:call(Ctx, '__main__', chain_schedule_py, [0, ChainLen])
+        end, lists:seq(1, N))
+    end),
+
+    %% Benchmark schedule_inline
+    {TimeInline, _} = timer:tc(fun() ->
+        lists:foreach(fun(_) ->
+            {ok, _} = py:call(Ctx, '__main__', chain_schedule_inline, [0, ChainLen])
+        end, lists:seq(1, N))
+    end),
+
+    TotalCalls = N * ChainLen,
+    PyMs = TimePy / 1000,
+    InlineMs = TimeInline / 1000,
+    Speedup = PyMs / InlineMs,
+
+    io:format("  Chain length: ~p~n", [ChainLen]),
+    io:format("  Total chained calls: ~p~n", [TotalCalls]),
+    io:format("~n"),
+    io:format("  schedule_py:~n"),
+    io:format("    Total: ~.2f ms~n", [PyMs]),
+    io:format("    Per chain: ~.3f ms~n", [PyMs / N]),
+    io:format("    Throughput: ~p chains/sec~n", [round(N / (PyMs / 1000))]),
+    io:format("~n"),
+    io:format("  schedule_inline:~n"),
+    io:format("    Total: ~.2f ms~n", [InlineMs]),
+    io:format("    Per chain: ~.3f ms~n", [InlineMs / N]),
+    io:format("    Throughput: ~p chains/sec~n", [round(N / (InlineMs / 1000))]),
+    io:format("~n"),
+    io:format("  Speedup: ~.2fx~n~n", [Speedup]).

--- a/test/py_schedule_SUITE.erl
+++ b/test/py_schedule_SUITE.erl
@@ -328,7 +328,9 @@ def call_inline_greet(name, prefix):
 %% Test schedule_inline transitioning to schedule_py (mixed schedule types)
 test_schedule_inline_to_schedule_py(_Config) ->
     %% Start with schedule_inline, then transition to schedule_py
-    ok = py:exec(<<"
+    %% Use explicit context to ensure consistent namespace
+    Ctx = py:context(),
+    ok = py:exec(Ctx, <<"
 import __main__
 
 def step1(x):
@@ -350,7 +352,7 @@ __main__.step2 = step2
 __main__.step3 = step3
 ">>),
     %% (5 * 2 + 10) * 3 = 60
-    {ok, Result} = py:eval(<<"step1(5)">>),
+    {ok, Result} = py:eval(Ctx, <<"step1(5)">>),
     ct:pal("schedule_inline to schedule_py result: ~p", [Result]),
     60 = Result,
     ok.

--- a/test/py_schedule_SUITE.erl
+++ b/test/py_schedule_SUITE.erl
@@ -133,22 +133,24 @@ assert isinstance(result, bool), f'Expected bool, got {type(result)}'
 
 %% Test schedule() with a registered Erlang callback
 test_schedule_with_callback(_Config) ->
+    Ctx = py:context(),
     %% Define the function
-    ok = py:exec(<<"
+    ok = py:exec(Ctx, <<"
 def schedule_add(a, b):
     import erlang
     return erlang.schedule('_test_add', a, b)
 ">>),
     %% Call it - the schedule marker should be detected and callback executed
-    {ok, Result} = py:eval(<<"schedule_add(5, 7)">>),
+    {ok, Result} = py:eval(Ctx, <<"schedule_add(5, 7)">>),
     ct:pal("schedule() result: ~p", [Result]),
     12 = Result,
     ok.
 
 %% Test schedule_py() basic functionality
 test_schedule_py_basic(_Config) ->
+    Ctx = py:context(),
     %% Define the target function in __main__ so it's accessible via py:call
-    ok = py:exec(<<"
+    ok = py:exec(Ctx, <<"
 import __main__
 
 def double(x):
@@ -162,14 +164,15 @@ def schedule_double(x):
     return erlang.schedule_py('__main__', 'double', [x])
 ">>),
     %% Call the scheduling function
-    {ok, Result} = py:eval(<<"schedule_double(5)">>),
+    {ok, Result} = py:eval(Ctx, <<"schedule_double(5)">>),
     ct:pal("schedule_py() result: ~p", [Result]),
     10 = Result,
     ok.
 
 %% Test schedule_py() with multiple args
 test_schedule_py_with_args(_Config) ->
-    ok = py:exec(<<"
+    Ctx = py:context(),
+    ok = py:exec(Ctx, <<"
 import __main__
 
 def add_three(a, b, c):
@@ -181,14 +184,15 @@ def schedule_add_three(a, b, c):
     import erlang
     return erlang.schedule_py('__main__', 'add_three', [a, b, c])
 ">>),
-    {ok, Result} = py:eval(<<"schedule_add_three(1, 2, 3)">>),
+    {ok, Result} = py:eval(Ctx, <<"schedule_add_three(1, 2, 3)">>),
     ct:pal("schedule_py() with args result: ~p", [Result]),
     6 = Result,
     ok.
 
 %% Test schedule_py() with kwargs
 test_schedule_py_with_kwargs(_Config) ->
-    ok = py:exec(<<"
+    Ctx = py:context(),
+    ok = py:exec(Ctx, <<"
 import __main__
 
 def greet(name, prefix='Hello'):
@@ -200,7 +204,7 @@ def schedule_greet(name, prefix):
     import erlang
     return erlang.schedule_py('__main__', 'greet', [name], {'prefix': prefix})
 ">>),
-    {ok, Result} = py:eval(<<"schedule_greet('World', 'Hi')">>),
+    {ok, Result} = py:eval(Ctx, <<"schedule_greet('World', 'Hi')">>),
     ct:pal("schedule_py() with kwargs result: ~p", [Result]),
     <<"Hi, World!">> = Result,
     ok.
@@ -252,7 +256,8 @@ assert isinstance(marker, erlang.InlineScheduleMarker), f'Expected InlineSchedul
 
 %% Test schedule_inline() basic functionality - single continuation
 test_schedule_inline_basic(_Config) ->
-    ok = py:exec(<<"
+    Ctx = py:context(),
+    ok = py:exec(Ctx, <<"
 import __main__
 
 def inline_double(x):
@@ -264,14 +269,15 @@ def call_inline_double(x):
     import erlang
     return erlang.schedule_inline('__main__', 'inline_double', args=[x])
 ">>),
-    {ok, Result} = py:eval(<<"call_inline_double(21)">>),
+    {ok, Result} = py:eval(Ctx, <<"call_inline_double(21)">>),
     ct:pal("schedule_inline() basic result: ~p", [Result]),
     42 = Result,
     ok.
 
 %% Test schedule_inline() with chained continuations
 test_schedule_inline_chain(_Config) ->
-    ok = py:exec(<<"
+    Ctx = py:context(),
+    ok = py:exec(Ctx, <<"
 import __main__
 
 def chain_step(n, acc):
@@ -284,14 +290,15 @@ def chain_step(n, acc):
 __main__.chain_step = chain_step
 ">>),
     %% Sum of 1 to 10 = 55
-    {ok, Result} = py:eval(<<"chain_step(10, 0)">>),
+    {ok, Result} = py:eval(Ctx, <<"chain_step(10, 0)">>),
     ct:pal("schedule_inline() chain result: ~p", [Result]),
     55 = Result,
     ok.
 
 %% Test schedule_inline() with multiple args
 test_schedule_inline_with_args(_Config) ->
-    ok = py:exec(<<"
+    Ctx = py:context(),
+    ok = py:exec(Ctx, <<"
 import __main__
 
 def inline_add(a, b, c):
@@ -303,14 +310,15 @@ def call_inline_add(a, b, c):
     import erlang
     return erlang.schedule_inline('__main__', 'inline_add', args=[a, b, c])
 ">>),
-    {ok, Result} = py:eval(<<"call_inline_add(10, 20, 30)">>),
+    {ok, Result} = py:eval(Ctx, <<"call_inline_add(10, 20, 30)">>),
     ct:pal("schedule_inline() with args result: ~p", [Result]),
     60 = Result,
     ok.
 
 %% Test schedule_inline() with kwargs
 test_schedule_inline_with_kwargs(_Config) ->
-    ok = py:exec(<<"
+    Ctx = py:context(),
+    ok = py:exec(Ctx, <<"
 import __main__
 
 def inline_greet(name, prefix='Hello'):
@@ -322,7 +330,7 @@ def call_inline_greet(name, prefix):
     import erlang
     return erlang.schedule_inline('__main__', 'inline_greet', args=[name], kwargs={'prefix': prefix})
 ">>),
-    {ok, Result} = py:eval(<<"call_inline_greet('Erlang', 'Greetings')">>),
+    {ok, Result} = py:eval(Ctx, <<"call_inline_greet('Erlang', 'Greetings')">>),
     ct:pal("schedule_inline() with kwargs result: ~p", [Result]),
     <<"Greetings, Erlang!">> = Result,
     ok.
@@ -361,12 +369,13 @@ __main__.step3 = step3
 
 %% Test schedule_inline error handling (function not found)
 test_schedule_inline_error(_Config) ->
-    ok = py:exec(<<"
+    Ctx = py:context(),
+    ok = py:exec(Ctx, <<"
 def call_nonexistent():
     import erlang
     return erlang.schedule_inline('__main__', 'nonexistent_function_xyz', args=[])
 ">>),
-    {error, Reason} = py:eval(<<"call_nonexistent()">>),
+    {error, Reason} = py:eval(Ctx, <<"call_nonexistent()">>),
     ct:pal("schedule_inline error: ~p", [Reason]),
     %% Should get a NameError - error comes as {ErrorType, Message} tuple or binary
     case Reason of

--- a/test/py_schedule_SUITE.erl
+++ b/test/py_schedule_SUITE.erl
@@ -25,6 +25,7 @@
     test_schedule_inline_with_kwargs/1,
     test_schedule_inline_to_schedule_py/1,
     test_schedule_inline_error/1,
+    test_schedule_inline_captures_globals/1,
     test_call_is_blocking/1
 ]).
 
@@ -48,6 +49,7 @@ all() ->
         test_schedule_inline_with_kwargs,
         test_schedule_inline_to_schedule_py,
         test_schedule_inline_error,
+        test_schedule_inline_captures_globals,
         test_call_is_blocking
     ].
 
@@ -373,4 +375,33 @@ def call_nonexistent():
         _ when is_list(Reason) -> ok;
         _ -> ct:fail("Unexpected error format: ~p", [Reason])
     end,
+    ok.
+
+%% Test that schedule_inline captures globals from caller's frame
+test_schedule_inline_captures_globals(_Config) ->
+    %% This test verifies that schedule_inline captures the caller's frame
+    %% globals and uses them for function lookup in the continuation.
+    %% This is important for subinterpreter support.
+    Ctx = py:context(),
+    ok = py:exec(Ctx, <<"
+import __main__
+
+# Define a helper function at module scope
+def helper_multiply(x):
+    return x * 3
+
+# Define an outer function that creates a local function reference
+# and uses schedule_inline to call it
+def test_captured_globals():
+    import erlang
+    # This should capture the current globals which includes helper_multiply
+    return erlang.schedule_inline('__main__', 'helper_multiply', args=[7])
+
+__main__.helper_multiply = helper_multiply
+__main__.test_captured_globals = test_captured_globals
+">>),
+    %% Call the function - should work because globals are captured
+    {ok, Result} = py:eval(Ctx, <<"test_captured_globals()">>),
+    ct:pal("schedule_inline captures globals result: ~p", [Result]),
+    21 = Result,  %% 7 * 3 = 21
     ok.

--- a/test/py_schedule_SUITE.erl
+++ b/test/py_schedule_SUITE.erl
@@ -1,4 +1,4 @@
-%% @doc Tests for erlang.schedule(), schedule_py(), and consume_time_slice().
+%% @doc Tests for erlang.schedule(), schedule_py(), schedule_inline() and consume_time_slice().
 %%
 %% Tests explicit scheduling API for cooperative dirty scheduler release.
 -module(py_schedule_SUITE).
@@ -9,14 +9,22 @@
 -export([
     test_schedule_available/1,
     test_schedule_py_available/1,
+    test_schedule_inline_available/1,
     test_consume_time_slice_available/1,
     test_schedule_returns_marker/1,
     test_schedule_py_returns_marker/1,
+    test_schedule_inline_returns_marker/1,
     test_consume_time_slice_returns_bool/1,
     test_schedule_with_callback/1,
     test_schedule_py_basic/1,
     test_schedule_py_with_args/1,
     test_schedule_py_with_kwargs/1,
+    test_schedule_inline_basic/1,
+    test_schedule_inline_chain/1,
+    test_schedule_inline_with_args/1,
+    test_schedule_inline_with_kwargs/1,
+    test_schedule_inline_to_schedule_py/1,
+    test_schedule_inline_error/1,
     test_call_is_blocking/1
 ]).
 
@@ -24,14 +32,22 @@ all() ->
     [
         test_schedule_available,
         test_schedule_py_available,
+        test_schedule_inline_available,
         test_consume_time_slice_available,
         test_schedule_returns_marker,
         test_schedule_py_returns_marker,
+        test_schedule_inline_returns_marker,
         test_consume_time_slice_returns_bool,
         test_schedule_with_callback,
         test_schedule_py_basic,
         test_schedule_py_with_args,
         test_schedule_py_with_kwargs,
+        test_schedule_inline_basic,
+        test_schedule_inline_chain,
+        test_schedule_inline_with_args,
+        test_schedule_inline_with_kwargs,
+        test_schedule_inline_to_schedule_py,
+        test_schedule_inline_error,
         test_call_is_blocking
     ].
 
@@ -207,4 +223,152 @@ result = test_call_once()
 assert result == 1, f'Expected 1, got {result} - call may have replayed'
 ">>),
     ct:pal("erlang.call() is blocking (no replay)"),
+    ok.
+
+%% ============================================================================
+%% schedule_inline tests
+%% ============================================================================
+
+%% Test that erlang.schedule_inline is available
+test_schedule_inline_available(_Config) ->
+    ok = py:exec(<<"
+import erlang
+assert hasattr(erlang, 'schedule_inline'), 'erlang.schedule_inline not found'
+">>),
+    ct:pal("erlang.schedule_inline is available"),
+    ok.
+
+%% Test that schedule_inline() returns an InlineScheduleMarker
+test_schedule_inline_returns_marker(_Config) ->
+    ok = py:exec(<<"
+import erlang
+marker = erlang.schedule_inline('math', 'sqrt', args=[16.0])
+assert isinstance(marker, erlang.InlineScheduleMarker), f'Expected InlineScheduleMarker, got {type(marker)}'
+">>),
+    ct:pal("schedule_inline() returns InlineScheduleMarker"),
+    ok.
+
+%% Test schedule_inline() basic functionality - single continuation
+test_schedule_inline_basic(_Config) ->
+    ok = py:exec(<<"
+import __main__
+
+def inline_double(x):
+    return x * 2
+
+__main__.inline_double = inline_double
+
+def call_inline_double(x):
+    import erlang
+    return erlang.schedule_inline('__main__', 'inline_double', args=[x])
+">>),
+    {ok, Result} = py:eval(<<"call_inline_double(21)">>),
+    ct:pal("schedule_inline() basic result: ~p", [Result]),
+    42 = Result,
+    ok.
+
+%% Test schedule_inline() with chained continuations
+test_schedule_inline_chain(_Config) ->
+    ok = py:exec(<<"
+import __main__
+
+def chain_step(n, acc):
+    import erlang
+    if n <= 0:
+        return acc
+    # Chain to next step via inline continuation
+    return erlang.schedule_inline('__main__', 'chain_step', args=[n - 1, acc + n])
+
+__main__.chain_step = chain_step
+">>),
+    %% Sum of 1 to 10 = 55
+    {ok, Result} = py:eval(<<"chain_step(10, 0)">>),
+    ct:pal("schedule_inline() chain result: ~p", [Result]),
+    55 = Result,
+    ok.
+
+%% Test schedule_inline() with multiple args
+test_schedule_inline_with_args(_Config) ->
+    ok = py:exec(<<"
+import __main__
+
+def inline_add(a, b, c):
+    return a + b + c
+
+__main__.inline_add = inline_add
+
+def call_inline_add(a, b, c):
+    import erlang
+    return erlang.schedule_inline('__main__', 'inline_add', args=[a, b, c])
+">>),
+    {ok, Result} = py:eval(<<"call_inline_add(10, 20, 30)">>),
+    ct:pal("schedule_inline() with args result: ~p", [Result]),
+    60 = Result,
+    ok.
+
+%% Test schedule_inline() with kwargs
+test_schedule_inline_with_kwargs(_Config) ->
+    ok = py:exec(<<"
+import __main__
+
+def inline_greet(name, prefix='Hello'):
+    return f'{prefix}, {name}!'
+
+__main__.inline_greet = inline_greet
+
+def call_inline_greet(name, prefix):
+    import erlang
+    return erlang.schedule_inline('__main__', 'inline_greet', args=[name], kwargs={'prefix': prefix})
+">>),
+    {ok, Result} = py:eval(<<"call_inline_greet('Erlang', 'Greetings')">>),
+    ct:pal("schedule_inline() with kwargs result: ~p", [Result]),
+    <<"Greetings, Erlang!">> = Result,
+    ok.
+
+%% Test schedule_inline transitioning to schedule_py (mixed schedule types)
+test_schedule_inline_to_schedule_py(_Config) ->
+    %% Start with schedule_inline, then transition to schedule_py
+    ok = py:exec(<<"
+import __main__
+
+def step1(x):
+    import erlang
+    # First step uses inline continuation
+    return erlang.schedule_inline('__main__', 'step2', args=[x * 2])
+
+def step2(x):
+    import erlang
+    # Second step switches to schedule_py (goes through Erlang messaging)
+    return erlang.schedule_py('__main__', 'step3', [x + 10])
+
+def step3(x):
+    # Final step returns result
+    return x * 3
+
+__main__.step1 = step1
+__main__.step2 = step2
+__main__.step3 = step3
+">>),
+    %% (5 * 2 + 10) * 3 = 60
+    {ok, Result} = py:eval(<<"step1(5)">>),
+    ct:pal("schedule_inline to schedule_py result: ~p", [Result]),
+    60 = Result,
+    ok.
+
+%% Test schedule_inline error handling (function not found)
+test_schedule_inline_error(_Config) ->
+    ok = py:exec(<<"
+def call_nonexistent():
+    import erlang
+    return erlang.schedule_inline('__main__', 'nonexistent_function_xyz', args=[])
+">>),
+    {error, Reason} = py:eval(<<"call_nonexistent()">>),
+    ct:pal("schedule_inline error: ~p", [Reason]),
+    %% Should get a NameError - error comes as {ErrorType, Message} tuple or binary
+    case Reason of
+        {'NameError', _Msg} -> ok;
+        _ when is_binary(Reason) -> ok;
+        _ when is_list(Reason) -> ok;
+        _ -> ct:fail("Unexpected error format: ~p", [Reason])
+    end,
     ok.


### PR DESCRIPTION
## Summary
- Add `erlang.schedule_inline()` which bypasses Erlang messaging using `enif_schedule_nif()` to chain Python calls directly
- Works with all `py:call()` variants
- Includes 8 new test cases

## Usage
```python
def process_batch(data, offset=0):
    # process chunk...
    if erlang.consume_time_slice(25):
        return erlang.schedule_inline('__main__', 'process_batch', args=[data, offset+100])
    return results
```