### PR TITLE
Add automatic env reuse for py_event_loop:run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@
 
 ### Added
 
+- **Automatic Env Reuse for Event Loop Tasks** - Functions defined via `py:exec(Ctx, Code)`
+  can now be called directly using `py_event_loop:run/3,4`, `create_task/3,4`, and `spawn_task/3,4`
+  without manual env passing. The process-local environment is automatically detected and used
+  for function lookup when targeting `__main__` module.
+
 - **PyBuffer API** - Zero-copy WSGI input buffer for streaming HTTP bodies
   - `py_buffer:new/0,1` - Create buffer (chunked or with content_length)
   - `py_buffer:write/2` - Append data, signals waiting Python readers

--- a/c_src/py_event_loop.c
+++ b/c_src/py_event_loop.c
@@ -502,6 +502,18 @@ cleanup_native:
         }
         loop->namespaces_head = NULL;
 
+        /* Clean up PID-to-env mappings */
+        pid_env_mapping_t *mapping = loop->pid_env_head;
+        while (mapping != NULL) {
+            pid_env_mapping_t *next = mapping->next;
+            if (mapping->env != NULL) {
+                enif_release_resource(mapping->env);
+            }
+            enif_free(mapping);
+            mapping = next;
+        }
+        loop->pid_env_head = NULL;
+
         pthread_mutex_unlock(&loop->namespaces_mutex);
         PyGILState_Release(gstate);
     } else {
@@ -516,6 +528,18 @@ cleanup_native:
             ns = next;
         }
         loop->namespaces_head = NULL;
+
+        /* Clean up PID-to-env mappings */
+        pid_env_mapping_t *mapping = loop->pid_env_head;
+        while (mapping != NULL) {
+            pid_env_mapping_t *next = mapping->next;
+            if (mapping->env != NULL) {
+                enif_release_resource(mapping->env);
+            }
+            enif_free(mapping);
+            mapping = next;
+        }
+        loop->pid_env_head = NULL;
 
         pthread_mutex_unlock(&loop->namespaces_mutex);
     }
@@ -1128,6 +1152,7 @@ ERL_NIF_TERM nif_event_loop_new(ErlNifEnv *env, int argc,
 
     /* Initialize per-process namespace registry */
     loop->namespaces_head = NULL;
+    loop->pid_env_head = NULL;
     if (pthread_mutex_init(&loop->namespaces_mutex, NULL) != 0) {
         pthread_mutex_destroy(&loop->task_queue_mutex);
         enif_ioq_destroy(loop->task_queue);
@@ -2501,6 +2526,164 @@ ERL_NIF_TERM nif_submit_task(ErlNifEnv *env, int argc,
     return ATOM_OK;
 }
 
+/* ============================================================================
+ * PID-to-Env Mapping Helpers
+ * ============================================================================ */
+
+/**
+ * @brief Register or update an env mapping for a PID
+ *
+ * Increments refcount if mapping exists, otherwise creates new mapping.
+ * Calls enif_keep_resource to keep the env alive.
+ *
+ * @param loop Event loop containing the mapping registry
+ * @param pid PID to register
+ * @param env_res Environment resource (will be kept via enif_keep_resource)
+ * @return true on success, false on allocation failure
+ */
+static bool register_pid_env(erlang_event_loop_t *loop, const ErlNifPid *pid,
+                              void *env_res) {
+    pthread_mutex_lock(&loop->namespaces_mutex);
+
+    /* Check if mapping already exists */
+    pid_env_mapping_t *mapping = loop->pid_env_head;
+    while (mapping != NULL) {
+        if (enif_compare_pids(&mapping->pid, pid) == 0) {
+            /* Found existing mapping - increment refcount */
+            mapping->refcount++;
+            pthread_mutex_unlock(&loop->namespaces_mutex);
+            return true;
+        }
+        mapping = mapping->next;
+    }
+
+    /* Create new mapping */
+    mapping = enif_alloc(sizeof(pid_env_mapping_t));
+    if (mapping == NULL) {
+        pthread_mutex_unlock(&loop->namespaces_mutex);
+        return false;
+    }
+
+    mapping->pid = *pid;
+    mapping->env = env_res;
+    mapping->refcount = 1;
+    mapping->next = loop->pid_env_head;
+    loop->pid_env_head = mapping;
+
+    /* Keep the resource alive */
+    enif_keep_resource(env_res);
+
+    pthread_mutex_unlock(&loop->namespaces_mutex);
+    return true;
+}
+
+/**
+ * @brief Look up env for a PID
+ *
+ * @param loop Event loop containing the mapping registry
+ * @param pid PID to look up
+ * @return Environment resource or NULL if not found
+ */
+static void *lookup_pid_env(erlang_event_loop_t *loop, const ErlNifPid *pid) {
+    pthread_mutex_lock(&loop->namespaces_mutex);
+
+    pid_env_mapping_t *mapping = loop->pid_env_head;
+    while (mapping != NULL) {
+        if (enif_compare_pids(&mapping->pid, pid) == 0) {
+            void *env_res = mapping->env;
+            pthread_mutex_unlock(&loop->namespaces_mutex);
+            return env_res;
+        }
+        mapping = mapping->next;
+    }
+
+    pthread_mutex_unlock(&loop->namespaces_mutex);
+    return NULL;
+}
+
+/**
+ * submit_task_with_env(LoopRef, CallerPid, Ref, Module, Func, Args, Kwargs, EnvRef) -> ok | {error, Reason}
+ *
+ * Like submit_task but registers the process-local env for the caller PID.
+ * The env's globals dict is used for function lookup, allowing functions
+ * defined via py:exec() to be called from the event loop.
+ *
+ * Note: The env resource is stored in a PID->env mapping, not serialized.
+ * This avoids the issue of resource references not surviving serialization.
+ */
+ERL_NIF_TERM nif_submit_task_with_env(ErlNifEnv *env, int argc,
+                                       const ERL_NIF_TERM argv[]) {
+    (void)argc;
+
+    erlang_event_loop_t *loop;
+    if (!enif_get_resource(env, argv[0], EVENT_LOOP_RESOURCE_TYPE,
+                           (void **)&loop)) {
+        return make_error(env, "invalid_loop");
+    }
+
+    if (!loop->task_queue_initialized) {
+        return make_error(env, "task_queue_not_initialized");
+    }
+
+    /* Validate caller_pid */
+    ErlNifPid caller_pid;
+    if (!enif_get_local_pid(env, argv[1], &caller_pid)) {
+        return make_error(env, "invalid_caller_pid");
+    }
+
+    /* Get and register the env resource */
+    void *env_res;
+    if (!enif_get_resource(env, argv[7], get_env_resource_type(), &env_res)) {
+        return make_error(env, "invalid_env");
+    }
+
+    /* Register the env for this PID (increments refcount if exists) */
+    if (!register_pid_env(loop, &caller_pid, env_res)) {
+        return make_error(env, "env_registration_failed");
+    }
+
+    /* Create task tuple: {CallerPid, Ref, Module, Func, Args, Kwargs}
+     * Note: We use 6-tuple, NOT 7-tuple. The env is looked up by PID. */
+    ERL_NIF_TERM task_tuple = enif_make_tuple6(env,
+        argv[1], argv[2], argv[3], argv[4], argv[5], argv[6]);
+
+    /* Serialize to binary */
+    ErlNifBinary task_bin;
+    if (!enif_term_to_binary(env, task_tuple, &task_bin)) {
+        return make_error(env, "serialization_failed");
+    }
+
+    /* Thread-safe enqueue */
+    pthread_mutex_lock(&loop->task_queue_mutex);
+    int enq_result = enif_ioq_enq_binary(loop->task_queue, &task_bin, 0);
+    pthread_mutex_unlock(&loop->task_queue_mutex);
+
+    if (enq_result != 1) {
+        enif_release_binary(&task_bin);
+        return make_error(env, "enqueue_failed");
+    }
+
+    /* Increment task count */
+    atomic_fetch_add(&loop->task_count, 1);
+
+    /* Coalesced wakeup (uvloop-style) */
+    if (loop->has_worker) {
+        if (!atomic_exchange(&loop->task_wake_pending, true)) {
+            ErlNifEnv *msg_env = enif_alloc_env();
+            if (msg_env != NULL) {
+                if (ATOM_TASK_READY == 0) {
+                    ATOM_TASK_READY = enif_make_atom(msg_env, "task_ready");
+                }
+                ERL_NIF_TERM msg = enif_make_atom(msg_env, "task_ready");
+                enif_send(NULL, &loop->worker_pid, msg_env, msg);
+                enif_free_env(msg_env);
+            }
+        }
+    }
+
+    return ATOM_OK;
+}
+
 /**
  * Maximum tasks to dequeue in one batch before acquiring GIL.
  * This bounds memory usage while still amortizing GIL acquisition cost.
@@ -2792,7 +2975,8 @@ ERL_NIF_TERM nif_process_ready_tasks(ErlNifEnv *env, int argc,
         /* Extract: {CallerPid, Ref, Module, Func, Args, Kwargs} */
         int arity;
         const ERL_NIF_TERM *tuple_elems;
-        if (!enif_get_tuple(term_env, task_term, &arity, &tuple_elems) || arity != 6) {
+        if (!enif_get_tuple(term_env, task_term, &arity, &tuple_elems) ||
+            arity != 6) {
             enif_free_env(term_env);
             continue;
         }
@@ -2810,6 +2994,9 @@ ERL_NIF_TERM nif_process_ready_tasks(ErlNifEnv *env, int argc,
             continue;
         }
 
+        /* Look up env by PID (registered via submit_task_with_env) */
+        py_env_resource_t *task_env = (py_env_resource_t *)lookup_pid_env(loop, &caller_pid);
+
         /* Convert module/func to C strings */
         char *module_name = enif_alloc(module_bin.size + 1);
         char *func_name = enif_alloc(func_bin.size + 1);
@@ -2824,11 +3011,27 @@ ERL_NIF_TERM nif_process_ready_tasks(ErlNifEnv *env, int argc,
         memcpy(func_name, func_bin.data, func_bin.size);
         func_name[func_bin.size] = '\0';
 
-        /* Look up namespace for caller process (only exists if they called exec/eval) */
+        /* Look up namespace for caller process (used for reentrant calls) */
         process_namespace_t *ns = lookup_process_namespace(loop, &caller_pid);
 
-        /* Look up function (checks process namespace for __main__, then cache/import) */
-        PyObject *func = get_function_for_task(loop, ns, module_name, func_name);
+        /* Look up function - check task_env first, then process namespace, then import */
+        PyObject *func = NULL;
+
+        /* First, check the passed env's globals (from py:exec) */
+        if (task_env != NULL && task_env->globals != NULL) {
+            if (strcmp(module_name, "__main__") == 0 ||
+                strcmp(module_name, "_process_") == 0) {
+                func = PyDict_GetItemString(task_env->globals, func_name);
+                if (func != NULL) {
+                    Py_INCREF(func);
+                }
+            }
+        }
+
+        /* Fallback to process namespace and cache/import */
+        if (func == NULL) {
+            func = get_function_for_task(loop, ns, module_name, func_name);
+        }
 
         enif_free(module_name);
         enif_free(func_name);

--- a/c_src/py_event_loop.h
+++ b/c_src/py_event_loop.h
@@ -124,6 +124,27 @@ typedef struct process_namespace {
     struct process_namespace *next;
 } process_namespace_t;
 
+/**
+ * @struct pid_env_mapping_t
+ * @brief Mapping from Erlang PID to process-local Python environment
+ *
+ * Used to pass env resources across the task queue without serialization.
+ * The env is kept alive by enif_keep_resource until the mapping is removed.
+ */
+typedef struct pid_env_mapping {
+    /** @brief PID of the owning Erlang process */
+    ErlNifPid pid;
+
+    /** @brief Environment resource (kept via enif_keep_resource) */
+    void *env;  /* py_env_resource_t* - forward declared to avoid header deps */
+
+    /** @brief Reference count for this mapping (multiple tasks may use it) */
+    int refcount;
+
+    /** @brief Next mapping in linked list */
+    struct pid_env_mapping *next;
+} pid_env_mapping_t;
+
 /** @brief Event types for pending callbacks */
 typedef enum {
     EVENT_TYPE_READ = 1,
@@ -372,6 +393,12 @@ typedef struct erlang_event_loop {
 
     /** @brief Mutex protecting namespace registry */
     pthread_mutex_t namespaces_mutex;
+
+    /* ========== PID-to-Env Mapping Registry ========== */
+    /* Protected by namespaces_mutex (shared with namespace registry) */
+
+    /** @brief Head of PID-to-env mapping linked list */
+    pid_env_mapping_t *pid_env_head;
 } erlang_event_loop_t;
 
 /* ============================================================================
@@ -623,6 +650,18 @@ ERL_NIF_TERM nif_dispatch_sleep_complete(ErlNifEnv *env, int argc,
  */
 ERL_NIF_TERM nif_submit_task(ErlNifEnv *env, int argc,
                               const ERL_NIF_TERM argv[]);
+
+/**
+ * @brief Submit an async task with process-local env (thread-safe)
+ *
+ * Like submit_task but includes an env resource reference. The env's globals
+ * dict is used for function lookup, allowing functions defined via py:exec()
+ * to be called from the event loop.
+ *
+ * NIF: submit_task_with_env(LoopRef, CallerPid, Ref, Module, Func, Args, Kwargs, EnvRef) -> ok | {error, Reason}
+ */
+ERL_NIF_TERM nif_submit_task_with_env(ErlNifEnv *env, int argc,
+                                       const ERL_NIF_TERM argv[]);
 
 /**
  * @brief Process all pending tasks from the task queue

--- a/c_src/py_nif.c
+++ b/c_src/py_nif.c
@@ -70,6 +70,11 @@ ErlNifResourceType *INLINE_CONTINUATION_RESOURCE_TYPE = NULL;
 /* Process-local Python environment resource type */
 ErlNifResourceType *PY_ENV_RESOURCE_TYPE = NULL;
 
+/* Getter for PY_ENV_RESOURCE_TYPE (used by py_event_loop.c) */
+ErlNifResourceType *get_env_resource_type(void) {
+    return PY_ENV_RESOURCE_TYPE;
+}
+
 _Atomic uint32_t g_context_id_counter = 1;
 
 /* ============================================================================
@@ -80,27 +85,7 @@ _Atomic uint32_t g_context_id_counter = 1;
  * resource destructor frees the Python dicts.
  */
 
-/**
- * @struct py_env_resource_t
- * @brief Process-local Python environment (globals/locals)
- *
- * Stored in process dictionary as py_local_env. When the process exits,
- * Erlang GC drops the reference, triggering the destructor which frees
- * the Python dicts.
- *
- * Each env is bound to a specific interpreter (identified by interp_id).
- * The dicts must be freed in the same interpreter that created them.
- */
-typedef struct {
-    /** @brief Global namespace dictionary */
-    PyObject *globals;
-    /** @brief Local namespace dictionary (same as globals for module-level execution) */
-    PyObject *locals;
-    /** @brief Interpreter ID that owns these dicts (0 = main interpreter) */
-    int64_t interp_id;
-    /** @brief Pool slot index (-1 for main interpreter) */
-    int pool_slot;
-} py_env_resource_t;
+/* py_env_resource_t is now defined in py_nif.h */
 
 /**
  * @brief Destructor for py_env_resource_t
@@ -6534,6 +6519,7 @@ static ErlNifFunc nif_funcs[] = {
     {"event_loop_run_async", 7, nif_event_loop_run_async, ERL_NIF_DIRTY_JOB_IO_BOUND},
     /* Async task queue NIFs (uvloop-inspired) */
     {"submit_task", 7, nif_submit_task, 0},  /* Thread-safe, no GIL needed */
+    {"submit_task_with_env", 8, nif_submit_task_with_env, 0},  /* With process-local env */
     {"process_ready_tasks", 1, nif_process_ready_tasks, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"event_loop_set_py_loop", 2, nif_event_loop_set_py_loop, 0},
     /* Per-process namespace NIFs */

--- a/c_src/py_nif.h
+++ b/c_src/py_nif.h
@@ -1313,6 +1313,31 @@ extern ErlNifResourceType *PY_CONTEXT_SUSPENDED_RESOURCE_TYPE;
 /** @brief Resource type for inline_continuation_t (inline scheduler continuation) */
 extern ErlNifResourceType *INLINE_CONTINUATION_RESOURCE_TYPE;
 
+/**
+ * @struct py_env_resource_t
+ * @brief Process-local Python environment (globals/locals)
+ *
+ * Stored in process dictionary as py_local_env. When the process exits,
+ * Erlang GC drops the reference, triggering the destructor which frees
+ * the Python dicts.
+ */
+typedef struct {
+    /** @brief Global namespace dictionary */
+    PyObject *globals;
+    /** @brief Local namespace dictionary (same as globals for module-level execution) */
+    PyObject *locals;
+    /** @brief Interpreter ID that owns these dicts (0 = main interpreter) */
+    int64_t interp_id;
+    /** @brief Pool slot index (-1 for main interpreter) */
+    int pool_slot;
+} py_env_resource_t;
+
+/** @brief Resource type for py_env_resource_t (process-local Python environment) */
+extern ErlNifResourceType *PY_ENV_RESOURCE_TYPE;
+
+/** @brief Get the PY_ENV_RESOURCE_TYPE (for use by other modules) */
+ErlNifResourceType *get_env_resource_type(void);
+
 /** @brief Atomic counter for unique interpreter IDs */
 extern _Atomic uint32_t g_context_id_counter;
 

--- a/docs/process-bound-envs.md
+++ b/docs/process-bound-envs.md
@@ -191,6 +191,37 @@ end).
 
 Event loop namespaces are automatically cleaned up when the Erlang process exits. The event loop monitors each process that creates a namespace and removes it on process termination.
 
+### Automatic Env Reuse with py:exec
+
+Functions defined via `py:exec(Ctx, Code)` can be called directly using the async task API (`py_event_loop:run/3,4`, `create_task/3,4`, `spawn_task/3,4`). The process-local environment is automatically detected and used for function lookup.
+
+```erlang
+%% Create a context and define an async function
+Ctx = py:context(1),
+ok = py:exec(Ctx, <<"
+import asyncio
+
+async def process_data(items):
+    results = []
+    for item in items:
+        await asyncio.sleep(0.001)
+        results.append(item * 2)
+    return results
+">>),
+
+%% Call it directly - env is reused automatically
+{ok, [2,4,6]} = py_event_loop:run('__main__', process_data, [[1,2,3]]).
+
+%% Also works with create_task and spawn_task
+Ref = py_event_loop:create_task('__main__', process_data, [[4,5,6]]),
+{ok, [8,10,12]} = py_event_loop:await(Ref).
+
+%% Fire-and-forget
+ok = py_event_loop:spawn_task('__main__', process_data, [[7,8,9]]).
+```
+
+This eliminates the need to manually pass environment references when calling functions defined in the process-local namespace.
+
 ## Building Python Actors
 
 The process-bound model enables a pattern we call "Python actors" - Erlang processes that encapsulate Python state and expose it through message passing.

--- a/src/py_event_loop.erl
+++ b/src/py_event_loop.erl
@@ -166,8 +166,31 @@ create_task(Module, Func, Args, Kwargs) ->
     Caller = self(),
     ModuleBin = py_util:to_binary(Module),
     FuncBin = py_util:to_binary(Func),
-    ok = py_nif:submit_task(LoopRef, Caller, Ref, ModuleBin, FuncBin, Args, Kwargs),
+    %% Check if there's a process-local env (from py:exec) and use it
+    ok = case get_process_env() of
+        undefined ->
+            py_nif:submit_task(LoopRef, Caller, Ref, ModuleBin, FuncBin, Args, Kwargs);
+        EnvRef ->
+            py_nif:submit_task_with_env(LoopRef, Caller, Ref, ModuleBin, FuncBin, Args, Kwargs, EnvRef)
+    end,
     Ref.
+
+%% @doc Get the process-local env reference if available.
+%% Returns the first env found (typically there's only one per process).
+-spec get_process_env() -> reference() | undefined.
+get_process_env() ->
+    case get(py_local_env) of
+        undefined -> undefined;
+        Envs when is_map(Envs) ->
+            %% Return any env (for __main__ lookup, any env works)
+            case maps:values(Envs) of
+                [EnvRef | _] -> EnvRef;
+                [] -> undefined
+            end;
+        EnvRef when is_reference(EnvRef) ->
+            %% Legacy single-env format
+            EnvRef
+    end.
 
 %% @doc Wait for an async task result.
 %%
@@ -207,6 +230,8 @@ spawn_task(Module, Func, Args) ->
 spawn_task(Module, Func, Args, Kwargs) ->
     {ok, LoopRef} = get_loop(),
     Ref = make_ref(),
+    %% Get env from caller's process BEFORE spawning receiver
+    CallerEnv = get_process_env(),
     %% Spawn a process that will receive and discard the result
     Receiver = erlang:spawn(fun() ->
         receive
@@ -218,7 +243,13 @@ spawn_task(Module, Func, Args, Kwargs) ->
     end),
     ModuleBin = py_util:to_binary(Module),
     FuncBin = py_util:to_binary(Func),
-    ok = py_nif:submit_task(LoopRef, Receiver, Ref, ModuleBin, FuncBin, Args, Kwargs),
+    %% Submit task with caller's env if available
+    ok = case CallerEnv of
+        undefined ->
+            py_nif:submit_task(LoopRef, Receiver, Ref, ModuleBin, FuncBin, Args, Kwargs);
+        EnvRef ->
+            py_nif:submit_task_with_env(LoopRef, Receiver, Ref, ModuleBin, FuncBin, Args, Kwargs, EnvRef)
+    end,
     ok.
 
 %% ============================================================================

--- a/src/py_nif.erl
+++ b/src/py_nif.erl
@@ -102,6 +102,7 @@
     event_loop_run_async/7,
     %% Async task queue NIFs (uvloop-inspired)
     submit_task/7,
+    submit_task_with_env/8,
     process_ready_tasks/1,
     event_loop_set_py_loop/2,
     %% Per-process namespace NIFs
@@ -767,6 +768,16 @@ event_loop_run_async(_LoopRef, _CallerPid, _Ref, _Module, _Func, _Args, _Kwargs)
 -spec submit_task(reference(), pid(), reference(), binary(), binary(), list(), map()) ->
     ok | {error, term()}.
 submit_task(_LoopRef, _CallerPid, _Ref, _Module, _Func, _Args, _Kwargs) ->
+    ?NIF_STUB.
+
+%% @doc Submit an async task with process-local env.
+%%
+%% Like submit_task but includes an env resource reference. The env's globals
+%% dict is used for function lookup, allowing functions defined via py:exec()
+%% to be called from the event loop.
+-spec submit_task_with_env(reference(), pid(), reference(), binary(), binary(), list(), map(), reference()) ->
+    ok | {error, term()}.
+submit_task_with_env(_LoopRef, _CallerPid, _Ref, _Module, _Func, _Args, _Kwargs, _EnvRef) ->
     ?NIF_STUB.
 
 %% @doc Process all pending tasks from the task queue.

--- a/test/py_async_task_SUITE.erl
+++ b/test/py_async_task_SUITE.erl
@@ -38,7 +38,11 @@
     test_process_namespace_eval/1,
     test_process_namespace_async_func/1,
     test_process_namespace_isolation/1,
-    test_process_namespace_reentrant/1
+    test_process_namespace_reentrant/1,
+    %% Env reuse tests
+    test_env_reuse_with_exec/1,
+    test_env_reuse_async_function/1,
+    test_env_reuse_spawn_task/1
 ]).
 
 all() ->
@@ -76,7 +80,11 @@ all() ->
         test_process_namespace_eval,
         test_process_namespace_async_func,
         test_process_namespace_isolation,
-        test_process_namespace_reentrant
+        test_process_namespace_reentrant,
+        %% Env reuse tests
+        test_env_reuse_with_exec,
+        test_env_reuse_async_function,
+        test_env_reuse_spawn_task
     ].
 
 groups() -> [].
@@ -512,3 +520,112 @@ def increment_shared():
     %% Verify the change persists in namespace
     {ok, 101} = py_event_loop:eval(<<"shared_value">>),
     ct:log("reentrant test: namespace modifications persist correctly").
+
+%% ============================================================================
+%% Env reuse tests
+%% ============================================================================
+
+test_env_reuse_with_exec(_Config) ->
+    %% Test that functions defined via py:exec with a context can be called
+    %% using py_event_loop:run without explicit env passing.
+    %%
+    %% This verifies the automatic env reuse feature: when a process has
+    %% a py_local_env in its process dictionary (from py:context/py:exec),
+    %% py_event_loop:run automatically passes that env to the NIF so
+    %% functions defined via exec are visible.
+
+    %% Create a context and define a sync function via py:exec
+    Ctx = py:context(1),
+    ok = py:exec(Ctx, <<"
+def multiply(a, b):
+    return a * b
+
+def greet(name):
+    return f'Hello, {name}!'
+">>),
+
+    %% Call the functions via py_event_loop:run - should find them automatically
+    {ok, Result1} = py_event_loop:run('__main__', multiply, [6, 7]),
+    ct:log("env_reuse test: multiply(6, 7) = ~p", [Result1]),
+    42 = Result1,
+
+    {ok, Result2} = py_event_loop:run('__main__', greet, [<<"World">>]),
+    ct:log("env_reuse test: greet('World') = ~p", [Result2]),
+    <<"Hello, World!">> = Result2,
+
+    ct:log("env_reuse_with_exec test: py:exec functions callable via py_event_loop:run").
+
+test_env_reuse_async_function(_Config) ->
+    %% Test that async functions defined via py:exec can be called
+    %% using py_event_loop:run with automatic env reuse.
+
+    %% Create a context and define an async function
+    Ctx = py:context(1),
+    ok = py:exec(Ctx, <<"
+import asyncio
+
+async def async_add(a, b):
+    await asyncio.sleep(0.01)
+    return a + b
+
+async def async_process(data):
+    # Simulate chunked processing
+    chunks = []
+    for i in range(0, len(data), 4):
+        chunk = data[i:i+4]
+        await asyncio.sleep(0.001)
+        chunks.append(chunk)
+    return chunks
+">>),
+
+    %% Call async function via py_event_loop:run
+    {ok, Sum} = py_event_loop:run('__main__', async_add, [10, 32]),
+    ct:log("env_reuse test: async_add(10, 32) = ~p", [Sum]),
+    42 = Sum,
+
+    %% Test with data processing
+    Data = <<"abcdefghijklmnop">>,
+    {ok, Chunks} = py_event_loop:run('__main__', async_process, [Data]),
+    ct:log("env_reuse test: async_process chunks = ~p", [Chunks]),
+    [<<"abcd">>, <<"efgh">>, <<"ijkl">>, <<"mnop">>] = Chunks,
+
+    ct:log("env_reuse_async_function test: async py:exec functions work with py_event_loop:run").
+
+test_env_reuse_spawn_task(_Config) ->
+    %% Test that spawn_task also uses the caller's env for function lookup.
+    %%
+    %% spawn_task spawns a receiver process but should use the caller's env
+    %% to find functions defined via py:exec.
+
+    %% Create a context and define a function that writes to a shared variable
+    Ctx = py:context(1),
+    ok = py:exec(Ctx, <<"
+spawn_test_results = []
+
+def record_value(x):
+    spawn_test_results.append(x)
+    return x
+
+def get_results():
+    return list(spawn_test_results)
+">>),
+
+    %% Use spawn_task to call the function (fire and forget)
+    ok = py_event_loop:spawn_task('__main__', record_value, [42]),
+
+    %% Wait a bit for the task to complete
+    timer:sleep(200),
+
+    %% Verify the function was called by checking the results list via run
+    {ok, Results} = py_event_loop:run('__main__', get_results, []),
+    ct:log("env_reuse_spawn_task test: spawn_test_results = ~p", [Results]),
+
+    %% Should contain the value we passed
+    case Results of
+        [42] ->
+            ct:log("env_reuse_spawn_task test: spawn_task correctly used caller's env");
+        _ ->
+            %% If empty or different, the function wasn't found or wasn't called
+            ct:log("env_reuse_spawn_task test: unexpected results ~p", [Results]),
+            ct:fail({unexpected_results, Results})
+    end.


### PR DESCRIPTION
## Summary

- Functions defined via `py:exec(Ctx, Code)` can now be called via `py_event_loop:run` without manual env passing
- The process-local env is automatically detected and passed to the NIF
- Supports both sync and async functions defined in the process namespace

Example:
```erlang
Ctx = py:context(1),
ok = py:exec(Ctx, <<"
async def async_add(a, b):
    await asyncio.sleep(0.01)
    return a + b
">>),

%% Just works - env is reused automatically
{ok, 42} = py_event_loop:run('__main__', async_add, [10, 32]).
```