### PR TITLE
Fix C audit findings

### DIFF
--- a/c_src/py_callback.c
+++ b/c_src/py_callback.c
@@ -2682,8 +2682,8 @@ static PyObject *erlang_channel_try_receive_impl(PyObject *self, PyObject *args)
  * Returns: Python object when data available
  * Raises: RuntimeError if channel closed, TimeoutError if timeout
  *
- * This function releases the GIL while waiting, allowing other Python
- * threads to run. Uses polling with short sleeps.
+ * This function releases the GIL while waiting on a condition variable,
+ * allowing other Python threads to run efficiently without polling.
  */
 static PyObject *erlang_channel_receive_impl(PyObject *self, PyObject *args) {
     (void)self;
@@ -2709,44 +2709,12 @@ static PyObject *erlang_channel_receive_impl(PyObject *self, PyObject *args) {
     size_t size = 0;
     int result;
 
-    /* First try without blocking */
-    result = channel_try_receive(channel, &data, &size);
-    if (result == 0) {
-        goto decode_and_return;
-    } else if (result == -1) {
-        PyErr_SetString(PyExc_RuntimeError, "channel closed");
-        return NULL;
-    }
+    /* Block on condition variable until data available, closed, or timeout */
+    Py_BEGIN_ALLOW_THREADS
+    result = channel_receive_blocking(channel, &data, &size, timeout_ms);
+    Py_END_ALLOW_THREADS
 
-    /* Need to wait - release GIL and poll */
-    {
-        long elapsed_us = 0;
-        const long poll_interval_us = 100;  /* 100 microseconds */
-        const long timeout_us = timeout_ms >= 0 ? timeout_ms * 1000 : -1;
-
-        Py_BEGIN_ALLOW_THREADS
-
-        while (1) {
-            result = channel_try_receive(channel, &data, &size);
-            if (result != 1) {
-                break;  /* Got data or closed */
-            }
-
-            /* Check timeout */
-            if (timeout_us >= 0 && elapsed_us >= timeout_us) {
-                result = 2;  /* Timeout */
-                break;
-            }
-
-            /* Sleep briefly */
-            usleep(poll_interval_us);
-            elapsed_us += poll_interval_us;
-        }
-
-        Py_END_ALLOW_THREADS
-    }
-
-    if (result == 2) {
+    if (result == 1) {
         PyErr_SetString(PyExc_TimeoutError, "channel receive timeout");
         return NULL;
     } else if (result == -1) {
@@ -2754,7 +2722,6 @@ static PyObject *erlang_channel_receive_impl(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-decode_and_return:
     /* Decode from Erlang external term format to Python */
     {
         ErlNifEnv *tmp_env = enif_alloc_env();
@@ -2945,8 +2912,8 @@ static PyObject *erlang_byte_channel_try_receive_bytes_impl(PyObject *self, PyOb
  * Returns: bytes when data available
  * Raises: RuntimeError if channel closed, TimeoutError if timeout
  *
- * This function releases the GIL while waiting, allowing other Python
- * threads to run. Uses polling with short sleeps.
+ * This function releases the GIL while waiting on a condition variable,
+ * allowing other Python threads to run efficiently without polling.
  */
 static PyObject *erlang_byte_channel_receive_bytes_impl(PyObject *self, PyObject *args) {
     (void)self;
@@ -2972,47 +2939,12 @@ static PyObject *erlang_byte_channel_receive_bytes_impl(PyObject *self, PyObject
     size_t size = 0;
     int result;
 
-    /* First try without blocking */
-    result = channel_try_receive(channel, &data, &size);
-    if (result == 0) {
-        /* Got data - return raw bytes */
-        PyObject *bytes = PyBytes_FromStringAndSize((char *)data, size);
-        enif_free(data);
-        return bytes;
-    } else if (result == -1) {
-        PyErr_SetString(PyExc_RuntimeError, "channel closed");
-        return NULL;
-    }
+    /* Block on condition variable until data available, closed, or timeout */
+    Py_BEGIN_ALLOW_THREADS
+    result = channel_receive_blocking(channel, &data, &size, timeout_ms);
+    Py_END_ALLOW_THREADS
 
-    /* Need to wait - release GIL and poll */
-    {
-        long elapsed_us = 0;
-        const long poll_interval_us = 100;  /* 100 microseconds */
-        const long timeout_us = timeout_ms >= 0 ? timeout_ms * 1000 : -1;
-
-        Py_BEGIN_ALLOW_THREADS
-
-        while (1) {
-            result = channel_try_receive(channel, &data, &size);
-            if (result != 1) {
-                break;  /* Got data or closed */
-            }
-
-            /* Check timeout */
-            if (timeout_us >= 0 && elapsed_us >= timeout_us) {
-                result = 2;  /* Timeout */
-                break;
-            }
-
-            /* Sleep briefly */
-            usleep(poll_interval_us);
-            elapsed_us += poll_interval_us;
-        }
-
-        Py_END_ALLOW_THREADS
-    }
-
-    if (result == 2) {
+    if (result == 1) {
         PyErr_SetString(PyExc_TimeoutError, "channel receive timeout");
         return NULL;
     } else if (result == -1) {

--- a/c_src/py_channel.c
+++ b/c_src/py_channel.c
@@ -69,6 +69,9 @@ void channel_resource_dtor(ErlNifEnv *env, void *obj) {
         channel->queue = NULL;
     }
 
+    /* Wake any threads waiting on the condition before destroying */
+    pthread_cond_broadcast(&channel->data_cond);
+    pthread_cond_destroy(&channel->data_cond);
     pthread_mutex_destroy(&channel->mutex);
 }
 
@@ -91,8 +94,6 @@ py_channel_t *channel_alloc(size_t max_size) {
 
     channel->max_size = max_size;
     channel->current_size = 0;
-    channel->waiting = NULL;
-    channel->waiting_callback_id = 0;
     channel->waiter_loop = NULL;
     channel->waiter_callback_id = 0;
     channel->has_waiter = false;
@@ -102,6 +103,13 @@ py_channel_t *channel_alloc(size_t max_size) {
     channel->channel_id = atomic_fetch_add(&g_channel_id_counter, 1);
 
     if (pthread_mutex_init(&channel->mutex, NULL) != 0) {
+        enif_ioq_destroy(channel->queue);
+        enif_release_resource(channel);
+        return NULL;
+    }
+
+    if (pthread_cond_init(&channel->data_cond, NULL) != 0) {
+        pthread_mutex_destroy(&channel->mutex);
         enif_ioq_destroy(channel->queue);
         enif_release_resource(channel);
         return NULL;
@@ -141,9 +149,6 @@ int channel_send(py_channel_t *channel, const unsigned char *data, size_t size) 
 
     channel->current_size += size;
 
-    /* Check if there's a waiting context to resume */
-    bool should_resume = (channel->waiting != NULL);
-
     /* Check if there's an async waiter to dispatch.
      * IMPORTANT: Clear waiter state BEFORE releasing mutex to avoid race condition.
      * With task_ready notification, the callback can fire before we re-acquire the mutex.
@@ -171,12 +176,10 @@ int channel_send(py_channel_t *channel, const unsigned char *data, size_t size) 
         channel->has_sync_waiter = false;
     }
 
-    pthread_mutex_unlock(&channel->mutex);
+    /* Signal any threads waiting on the condition variable */
+    pthread_cond_signal(&channel->data_cond);
 
-    /* Resume happens outside the lock to avoid deadlocks */
-    if (should_resume) {
-        channel_resume_waiting(channel);
-    }
+    pthread_mutex_unlock(&channel->mutex);
 
     /* Dispatch async waiter via timer dispatch (same path as timers) */
     if (loop_to_wake != NULL) {
@@ -225,9 +228,6 @@ int channel_send_owned_binary(py_channel_t *channel, ErlNifBinary *bin) {
 
     channel->current_size += msg_size;
 
-    /* Check if there's a waiting context to resume */
-    bool should_resume = (channel->waiting != NULL);
-
     /* Check if there's an async waiter to dispatch.
      * IMPORTANT: Clear waiter state BEFORE releasing mutex to avoid race condition.
      * With task_ready notification, the callback can fire before we re-acquire the mutex.
@@ -255,11 +255,10 @@ int channel_send_owned_binary(py_channel_t *channel, ErlNifBinary *bin) {
         channel->has_sync_waiter = false;
     }
 
-    pthread_mutex_unlock(&channel->mutex);
+    /* Signal any threads waiting on the condition variable */
+    pthread_cond_signal(&channel->data_cond);
 
-    if (should_resume) {
-        channel_resume_waiting(channel);
-    }
+    pthread_mutex_unlock(&channel->mutex);
 
     /* Dispatch async waiter via timer dispatch (same path as timers) */
     if (loop_to_wake != NULL) {
@@ -326,10 +325,80 @@ int channel_try_receive(py_channel_t *channel, unsigned char **out_data, size_t 
     return 0;
 }
 
+int channel_receive_blocking(py_channel_t *channel, unsigned char **out_data,
+                             size_t *out_size, long timeout_ms) {
+    pthread_mutex_lock(&channel->mutex);
+
+    /* Calculate deadline for timed wait */
+    struct timespec deadline;
+    if (timeout_ms > 0) {
+        clock_gettime(CLOCK_REALTIME, &deadline);
+        deadline.tv_sec += timeout_ms / 1000;
+        deadline.tv_nsec += (timeout_ms % 1000) * 1000000;
+        if (deadline.tv_nsec >= 1000000000) {
+            deadline.tv_sec++;
+            deadline.tv_nsec -= 1000000000;
+        }
+    }
+
+    /* Wait for data or close */
+    while (enif_ioq_size(channel->queue) == 0 && !channel->closed) {
+        if (timeout_ms == 0) {
+            /* Non-blocking: return immediately if no data */
+            pthread_mutex_unlock(&channel->mutex);
+            return 1;  /* Empty/timeout */
+        } else if (timeout_ms < 0) {
+            /* Infinite wait */
+            pthread_cond_wait(&channel->data_cond, &channel->mutex);
+        } else {
+            /* Timed wait */
+            int rc = pthread_cond_timedwait(&channel->data_cond, &channel->mutex, &deadline);
+            if (rc == ETIMEDOUT) {
+                pthread_mutex_unlock(&channel->mutex);
+                return 1;  /* Timeout */
+            }
+        }
+    }
+
+    /* Check if closed with no data */
+    if (channel->closed && enif_ioq_size(channel->queue) == 0) {
+        pthread_mutex_unlock(&channel->mutex);
+        return -1;  /* Closed */
+    }
+
+    /* We have data - dequeue it */
+    SysIOVec *iov;
+    int iovcnt;
+    iov = enif_ioq_peek(channel->queue, &iovcnt);
+
+    if (iovcnt == 0 || iov == NULL || iov[0].iov_len == 0) {
+        pthread_mutex_unlock(&channel->mutex);
+        return 1;  /* Spurious wakeup, no data */
+    }
+
+    size_t msg_size = iov[0].iov_len;
+
+    /* Allocate output buffer */
+    *out_data = enif_alloc(msg_size);
+    if (*out_data == NULL) {
+        pthread_mutex_unlock(&channel->mutex);
+        return -1;  /* Allocation error */
+    }
+
+    /* Copy data and dequeue */
+    memcpy(*out_data, iov[0].iov_base, msg_size);
+    *out_size = msg_size;
+
+    enif_ioq_deq(channel->queue, msg_size, NULL);
+    channel->current_size -= msg_size;
+
+    pthread_mutex_unlock(&channel->mutex);
+    return 0;
+}
+
 void channel_close(py_channel_t *channel) {
     pthread_mutex_lock(&channel->mutex);
     channel->closed = true;
-    bool should_resume = (channel->waiting != NULL);
 
     /* Check if there's an async waiter to dispatch.
      * For close, we unconditionally clear the waiter since the channel
@@ -354,11 +423,10 @@ void channel_close(py_channel_t *channel) {
         channel->has_sync_waiter = false;
     }
 
-    pthread_mutex_unlock(&channel->mutex);
+    /* Wake all threads waiting on the condition variable */
+    pthread_cond_broadcast(&channel->data_cond);
 
-    if (should_resume) {
-        channel_resume_waiting(channel);
-    }
+    pthread_mutex_unlock(&channel->mutex);
 
     /* Dispatch async waiter to signal closure */
     if (loop_to_wake != NULL) {
@@ -375,13 +443,6 @@ void channel_close(py_channel_t *channel) {
             enif_free_env(msg_env);
         }
     }
-}
-
-void channel_resume_waiting(py_channel_t *channel) {
-    /* This function would trigger resume of the suspended context.
-     * For now, the actual resume logic is handled in the NIF receive function
-     * by checking if data is available before suspending. */
-    (void)channel;
 }
 
 int channel_init(ErlNifEnv *env) {

--- a/c_src/py_channel.h
+++ b/c_src/py_channel.h
@@ -86,11 +86,8 @@ typedef struct {
     /** @brief Mutex for thread-safe queue access */
     pthread_mutex_t mutex;
 
-    /** @brief Suspended Python context waiting on this channel */
-    struct suspended_context_state *waiting;
-
-    /** @brief Callback ID for the waiting context */
-    uint64_t waiting_callback_id;
+    /** @brief Condition variable for blocking receives */
+    pthread_cond_t data_cond;
 
     /** @brief Event loop for async waiter (ref-counted via enif_keep_resource) */
     struct erlang_event_loop *waiter_loop;
@@ -175,6 +172,21 @@ int channel_send_owned_binary(py_channel_t *channel, ErlNifBinary *bin);
 int channel_try_receive(py_channel_t *channel, unsigned char **out_data, size_t *out_size);
 
 /**
+ * @brief Receive a message from a channel (blocking with timeout)
+ *
+ * Blocks on a condition variable until data is available, channel is closed,
+ * or timeout expires. This is more efficient than polling.
+ *
+ * @param channel Channel to receive from
+ * @param out_data Output: message data (caller must free with enif_free)
+ * @param out_size Output: message size
+ * @param timeout_ms Timeout in milliseconds (-1 for infinite, 0 for non-blocking)
+ * @return 0 on success, 1 if timeout, -1 if closed
+ */
+int channel_receive_blocking(py_channel_t *channel, unsigned char **out_data,
+                             size_t *out_size, long timeout_ms);
+
+/**
  * @brief Close a channel
  *
  * Closes the channel and wakes any waiting receivers with StopIteration.
@@ -182,15 +194,6 @@ int channel_try_receive(py_channel_t *channel, unsigned char **out_data, size_t 
  * @param channel Channel to close
  */
 void channel_close(py_channel_t *channel);
-
-/**
- * @brief Resume a waiting Python context with channel data
- *
- * Called when data becomes available for a suspended receive.
- *
- * @param channel Channel with waiting context
- */
-void channel_resume_waiting(py_channel_t *channel);
 
 /* ============================================================================
  * Channel NIF Declarations

--- a/c_src/py_nif.c
+++ b/c_src/py_nif.c
@@ -1503,7 +1503,10 @@ static ERL_NIF_TERM nif_worker_call(ErlNifEnv *env, int argc, const ERL_NIF_TERM
     }
 
     /* Submit to executor and wait */
-    executor_enqueue(&req);
+    if (executor_enqueue(&req) != 0) {
+        request_cleanup(&req);
+        return make_error(env, "runtime_shutting_down");
+    }
     executor_wait(&req);
 
     ERL_NIF_TERM result = req.result;
@@ -1535,7 +1538,10 @@ static ERL_NIF_TERM nif_worker_eval(ErlNifEnv *env, int argc, const ERL_NIF_TERM
         enif_get_ulong(env, argv[3], &req.timeout_ms);
     }
 
-    executor_enqueue(&req);
+    if (executor_enqueue(&req) != 0) {
+        request_cleanup(&req);
+        return make_error(env, "runtime_shutting_down");
+    }
     executor_wait(&req);
 
     ERL_NIF_TERM result = req.result;
@@ -1562,7 +1568,10 @@ static ERL_NIF_TERM nif_worker_exec(ErlNifEnv *env, int argc, const ERL_NIF_TERM
         return make_error(env, "invalid_code");
     }
 
-    executor_enqueue(&req);
+    if (executor_enqueue(&req) != 0) {
+        request_cleanup(&req);
+        return make_error(env, "runtime_shutting_down");
+    }
     executor_wait(&req);
 
     ERL_NIF_TERM result = req.result;
@@ -1589,7 +1598,10 @@ static ERL_NIF_TERM nif_worker_next(ErlNifEnv *env, int argc, const ERL_NIF_TERM
     req.env = env;
     req.gen_wrapper = gen_wrapper;
 
-    executor_enqueue(&req);
+    if (executor_enqueue(&req) != 0) {
+        request_cleanup(&req);
+        return make_error(env, "runtime_shutting_down");
+    }
     executor_wait(&req);
 
     ERL_NIF_TERM result = req.result;
@@ -1616,7 +1628,10 @@ static ERL_NIF_TERM nif_import_module(ErlNifEnv *env, int argc, const ERL_NIF_TE
         return make_error(env, "invalid_module");
     }
 
-    executor_enqueue(&req);
+    if (executor_enqueue(&req) != 0) {
+        request_cleanup(&req);
+        return make_error(env, "runtime_shutting_down");
+    }
     executor_wait(&req);
 
     ERL_NIF_TERM result = req.result;
@@ -1648,7 +1663,10 @@ static ERL_NIF_TERM nif_get_attr(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
         return make_error(env, "invalid_attr");
     }
 
-    executor_enqueue(&req);
+    if (executor_enqueue(&req) != 0) {
+        request_cleanup(&req);
+        return make_error(env, "runtime_shutting_down");
+    }
     executor_wait(&req);
 
     ERL_NIF_TERM result = req.result;
@@ -1686,7 +1704,10 @@ static ERL_NIF_TERM nif_memory_stats(ErlNifEnv *env, int argc, const ERL_NIF_TER
     req.type = PY_REQ_MEMORY_STATS;
     req.env = env;
 
-    executor_enqueue(&req);
+    if (executor_enqueue(&req) != 0) {
+        request_cleanup(&req);
+        return make_error(env, "runtime_shutting_down");
+    }
     executor_wait(&req);
 
     ERL_NIF_TERM result = req.result;
@@ -1763,7 +1784,10 @@ static ERL_NIF_TERM nif_gc(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) 
         enif_get_int(env, argv[0], &req.gc_generation);
     }
 
-    executor_enqueue(&req);
+    if (executor_enqueue(&req) != 0) {
+        request_cleanup(&req);
+        return make_error(env, "runtime_shutting_down");
+    }
     executor_wait(&req);
 
     ERL_NIF_TERM result = req.result;

--- a/c_src/py_nif.c
+++ b/c_src/py_nif.c
@@ -4115,8 +4115,12 @@ static int owngil_context_init(py_context_t *ctx) {
 /**
  * @brief Shutdown OWN_GIL context and clean up resources
  *
+ * Uses a timeout to avoid hanging forever if the Python thread is stuck.
+ *
  * @param ctx Context to shutdown
  */
+#define OWNGIL_SHUTDOWN_TIMEOUT_SECS 30
+
 static void owngil_context_shutdown(py_context_t *ctx) {
     if (!ctx->uses_own_gil) {
         return;
@@ -4130,8 +4134,33 @@ static void owngil_context_shutdown(py_context_t *ctx) {
     pthread_cond_signal(&ctx->request_ready);
     pthread_mutex_unlock(&ctx->request_mutex);
 
-    /* Wait for thread to exit */
-    pthread_join(ctx->own_gil_thread, NULL);
+    /* Wait for thread to exit with timeout */
+#if defined(__linux__)
+    struct timespec deadline;
+    clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_sec += OWNGIL_SHUTDOWN_TIMEOUT_SECS;
+    int rc = pthread_timedjoin_np(ctx->own_gil_thread, NULL, &deadline);
+    if (rc == ETIMEDOUT) {
+        fprintf(stderr, "OWN_GIL shutdown timeout after %d seconds, detaching thread\n",
+                OWNGIL_SHUTDOWN_TIMEOUT_SECS);
+        pthread_detach(ctx->own_gil_thread);
+    }
+#else
+    /* macOS/other: poll thread_running flag with timeout */
+    int wait_ms = 0;
+    while (atomic_load(&ctx->thread_running) &&
+           wait_ms < OWNGIL_SHUTDOWN_TIMEOUT_SECS * 1000) {
+        usleep(100000);  /* 100ms */
+        wait_ms += 100;
+    }
+    if (atomic_load(&ctx->thread_running)) {
+        fprintf(stderr, "OWN_GIL shutdown timeout after %d seconds, detaching thread\n",
+                OWNGIL_SHUTDOWN_TIMEOUT_SECS);
+        pthread_detach(ctx->own_gil_thread);
+    } else {
+        pthread_join(ctx->own_gil_thread, NULL);
+    }
+#endif
 
     /* Clean up resources */
     if (ctx->shared_env != NULL) {

--- a/c_src/py_subinterp_pool.c
+++ b/c_src/py_subinterp_pool.c
@@ -211,13 +211,16 @@ int subinterp_pool_init(int size) {
     return 0;
 }
 
+#define POOL_ALLOC_MAX_RETRIES 100
+
 int subinterp_pool_alloc(void) {
     if (!atomic_load(&g_pool_initialized)) {
         return -1;
     }
 
-    /* Try to find and allocate a free slot using CAS */
-    while (1) {
+    /* Try to find and allocate a free slot using CAS with bounded retries */
+    int retries = 0;
+    while (retries < POOL_ALLOC_MAX_RETRIES) {
         uint64_t current = atomic_load(&g_pool_allocation);
 
         /* Find first free bit (0 bit) */
@@ -239,8 +242,16 @@ int subinterp_pool_alloc(void) {
         if (atomic_compare_exchange_weak(&g_pool_allocation, &current, new_val)) {
             return slot;
         }
-        /* CAS failed, retry */
+
+        /* CAS failed, back off briefly after initial fast retries */
+        retries++;
+        if (retries > 10) {
+            usleep(1);
+        }
     }
+
+    /* Too much contention, give up */
+    return -1;
 }
 
 void subinterp_pool_free(int slot) {

--- a/priv/_erlang_impl/_byte_channel.py
+++ b/priv/_erlang_impl/_byte_channel.py
@@ -270,16 +270,33 @@ class ByteChannel:
             loop._timers.pop(callback_id, None)
 
     async def _async_receive_polling(self) -> bytes:
-        """Fallback async receive using polling."""
-        import asyncio
+        """Fallback async receive for non-Erlang event loops.
 
+        Uses run_in_executor to run blocking receive in a thread pool,
+        avoiding busy-polling while still releasing the event loop.
+        """
+        import asyncio
+        import erlang
+
+        loop = asyncio.get_running_loop()
+
+        # Run blocking receive in thread pool (releases GIL, waits on condition var)
+        # Use 100ms timeout chunks to allow cancellation checks
         while True:
-            await asyncio.sleep(0.0001)  # 100us yield
-            result = self.try_receive_bytes()
-            if result is not None:
+            try:
+                result = await loop.run_in_executor(
+                    None,
+                    lambda: erlang._byte_channel_receive_bytes(self._ref, 100)  # 100ms timeout
+                )
                 return result
-            if self._is_closed():
-                raise ByteChannelClosed("Channel closed")
+            except TimeoutError:
+                # Check for cancellation, then retry
+                await asyncio.sleep(0)
+                continue
+            except RuntimeError as e:
+                if "channel closed" in str(e).lower():
+                    raise ByteChannelClosed("Channel closed")
+                raise
 
     def __aiter__(self):
         """Return async iterator for the byte channel.

--- a/priv/_erlang_impl/_channel.py
+++ b/priv/_erlang_impl/_channel.py
@@ -247,16 +247,33 @@ class Channel:
             loop._timers.pop(callback_id, None)
 
     async def _async_receive_polling(self):
-        """Fallback async receive using polling."""
-        import asyncio
+        """Fallback async receive for non-Erlang event loops.
 
+        Uses run_in_executor to run blocking receive in a thread pool,
+        avoiding busy-polling while still releasing the event loop.
+        """
+        import asyncio
+        import erlang
+
+        loop = asyncio.get_running_loop()
+
+        # Run blocking receive in thread pool (releases GIL, waits on condition var)
+        # Use 100ms timeout chunks to allow cancellation checks
         while True:
-            await asyncio.sleep(0.0001)  # 100us yield
-            result = self.try_receive()
-            if result is not None:
+            try:
+                result = await loop.run_in_executor(
+                    None,
+                    lambda: erlang._channel_receive(self._ref, 100)  # 100ms timeout
+                )
                 return result
-            if self._is_closed():
-                raise ChannelClosed("Channel closed")
+            except TimeoutError:
+                # Check for cancellation, then retry
+                await asyncio.sleep(0)
+                continue
+            except RuntimeError as e:
+                if "channel closed" in str(e).lower():
+                    raise ChannelClosed("Channel closed")
+                raise
 
     def __aiter__(self):
         """Return async iterator for the channel.


### PR DESCRIPTION
## Summary

- Fix executor deadlock during shutdown
- Add timeout to OWN_GIL context shutdown
- Bound CAS retries in subinterpreter pool allocation
- Replace channel polling with condition variable

Tested with Python 3.9 and 3.14.