### PR TITLE
Refactor C source to consolidate duplicate patterns

### DIFF
--- a/c_src/py_callback.c
+++ b/c_src/py_callback.c
@@ -2626,14 +2626,9 @@ static PyObject *erlang_channel_try_receive_impl(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    if (!PyCapsule_CheckExact(capsule)) {
-        PyErr_SetString(PyExc_TypeError, "expected channel reference");
-        return NULL;
-    }
-
-    py_channel_t *channel = (py_channel_t *)PyCapsule_GetPointer(capsule, CHANNEL_CAPSULE_NAME);
+    py_channel_t *channel = (py_channel_t *)get_capsule_pointer_or_fail(
+        capsule, CHANNEL_CAPSULE_NAME, "channel");
     if (channel == NULL) {
-        PyErr_SetString(PyExc_ValueError, "invalid channel reference");
         return NULL;
     }
 
@@ -2644,27 +2639,7 @@ static PyObject *erlang_channel_try_receive_impl(PyObject *self, PyObject *args)
 
     if (result == 0) {
         /* Success - decode from Erlang external term format to Python */
-        ErlNifEnv *tmp_env = enif_alloc_env();
-        if (tmp_env == NULL) {
-            enif_free(data);
-            PyErr_SetString(PyExc_MemoryError, "failed to allocate environment");
-            return NULL;
-        }
-
-        ERL_NIF_TERM term;
-        if (enif_binary_to_term(tmp_env, data, size, &term, 0) == 0) {
-            enif_free(data);
-            enif_free_env(tmp_env);
-            PyErr_SetString(PyExc_RuntimeError, "failed to decode term");
-            return NULL;
-        }
-        enif_free(data);
-
-        /* Convert Erlang term to Python object */
-        PyObject *py_obj = term_to_py(tmp_env, term);
-        enif_free_env(tmp_env);
-
-        return py_obj;  /* May be NULL if conversion failed */
+        return decode_etf_to_python(data, size);
     } else if (result == 1) {
         /* Empty */
         Py_RETURN_NONE;
@@ -2694,14 +2669,9 @@ static PyObject *erlang_channel_receive_impl(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    if (!PyCapsule_CheckExact(capsule)) {
-        PyErr_SetString(PyExc_TypeError, "expected channel reference");
-        return NULL;
-    }
-
-    py_channel_t *channel = (py_channel_t *)PyCapsule_GetPointer(capsule, CHANNEL_CAPSULE_NAME);
+    py_channel_t *channel = (py_channel_t *)get_capsule_pointer_or_fail(
+        capsule, CHANNEL_CAPSULE_NAME, "channel");
     if (channel == NULL) {
-        PyErr_SetString(PyExc_ValueError, "invalid channel reference");
         return NULL;
     }
 
@@ -2723,29 +2693,7 @@ static PyObject *erlang_channel_receive_impl(PyObject *self, PyObject *args) {
     }
 
     /* Decode from Erlang external term format to Python */
-    {
-        ErlNifEnv *tmp_env = enif_alloc_env();
-        if (tmp_env == NULL) {
-            enif_free(data);
-            PyErr_SetString(PyExc_MemoryError, "failed to allocate environment");
-            return NULL;
-        }
-
-        ERL_NIF_TERM term;
-        if (enif_binary_to_term(tmp_env, data, size, &term, 0) == 0) {
-            enif_free(data);
-            enif_free_env(tmp_env);
-            PyErr_SetString(PyExc_RuntimeError, "failed to decode term");
-            return NULL;
-        }
-        enif_free(data);
-
-        /* Convert Erlang term to Python object */
-        PyObject *py_obj = term_to_py(tmp_env, term);
-        enif_free_env(tmp_env);
-
-        return py_obj;  /* May be NULL if conversion failed */
-    }
+    return decode_etf_to_python(data, size);
 }
 
 /**
@@ -2764,16 +2712,10 @@ static PyObject *erlang_channel_send_impl(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    if (!PyCapsule_CheckExact(capsule)) {
-        PyBuffer_Release(&buffer);
-        PyErr_SetString(PyExc_TypeError, "expected channel reference");
-        return NULL;
-    }
-
-    py_channel_t *channel = (py_channel_t *)PyCapsule_GetPointer(capsule, CHANNEL_CAPSULE_NAME);
+    py_channel_t *channel = (py_channel_t *)get_capsule_pointer_or_fail(
+        capsule, CHANNEL_CAPSULE_NAME, "channel");
     if (channel == NULL) {
         PyBuffer_Release(&buffer);
-        PyErr_SetString(PyExc_ValueError, "invalid channel reference");
         return NULL;
     }
 
@@ -2805,14 +2747,9 @@ static PyObject *erlang_channel_is_closed_impl(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    if (!PyCapsule_CheckExact(capsule)) {
-        PyErr_SetString(PyExc_TypeError, "expected channel reference");
-        return NULL;
-    }
-
-    py_channel_t *channel = (py_channel_t *)PyCapsule_GetPointer(capsule, CHANNEL_CAPSULE_NAME);
+    py_channel_t *channel = (py_channel_t *)get_capsule_pointer_or_fail(
+        capsule, CHANNEL_CAPSULE_NAME, "channel");
     if (channel == NULL) {
-        PyErr_SetString(PyExc_ValueError, "invalid channel reference");
         return NULL;
     }
 
@@ -2838,14 +2775,9 @@ static PyObject *erlang_channel_close_impl(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    if (!PyCapsule_CheckExact(capsule)) {
-        PyErr_SetString(PyExc_TypeError, "expected channel reference");
-        return NULL;
-    }
-
-    py_channel_t *channel = (py_channel_t *)PyCapsule_GetPointer(capsule, CHANNEL_CAPSULE_NAME);
+    py_channel_t *channel = (py_channel_t *)get_capsule_pointer_or_fail(
+        capsule, CHANNEL_CAPSULE_NAME, "channel");
     if (channel == NULL) {
-        PyErr_SetString(PyExc_ValueError, "invalid channel reference");
         return NULL;
     }
 
@@ -2874,14 +2806,9 @@ static PyObject *erlang_byte_channel_try_receive_bytes_impl(PyObject *self, PyOb
         return NULL;
     }
 
-    if (!PyCapsule_CheckExact(capsule)) {
-        PyErr_SetString(PyExc_TypeError, "expected channel reference");
-        return NULL;
-    }
-
-    py_channel_t *channel = (py_channel_t *)PyCapsule_GetPointer(capsule, CHANNEL_CAPSULE_NAME);
+    py_channel_t *channel = (py_channel_t *)get_capsule_pointer_or_fail(
+        capsule, CHANNEL_CAPSULE_NAME, "channel");
     if (channel == NULL) {
-        PyErr_SetString(PyExc_ValueError, "invalid channel reference");
         return NULL;
     }
 
@@ -2924,14 +2851,9 @@ static PyObject *erlang_byte_channel_receive_bytes_impl(PyObject *self, PyObject
         return NULL;
     }
 
-    if (!PyCapsule_CheckExact(capsule)) {
-        PyErr_SetString(PyExc_TypeError, "expected channel reference");
-        return NULL;
-    }
-
-    py_channel_t *channel = (py_channel_t *)PyCapsule_GetPointer(capsule, CHANNEL_CAPSULE_NAME);
+    py_channel_t *channel = (py_channel_t *)get_capsule_pointer_or_fail(
+        capsule, CHANNEL_CAPSULE_NAME, "channel");
     if (channel == NULL) {
-        PyErr_SetString(PyExc_ValueError, "invalid channel reference");
         return NULL;
     }
 
@@ -2978,25 +2900,15 @@ static PyObject *erlang_channel_wait_impl(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    if (!PyCapsule_CheckExact(ch_capsule)) {
-        PyErr_SetString(PyExc_TypeError, "expected channel reference");
-        return NULL;
-    }
-
-    py_channel_t *channel = (py_channel_t *)PyCapsule_GetPointer(ch_capsule, CHANNEL_CAPSULE_NAME);
+    py_channel_t *channel = (py_channel_t *)get_capsule_pointer_or_fail(
+        ch_capsule, CHANNEL_CAPSULE_NAME, "channel");
     if (channel == NULL) {
-        PyErr_SetString(PyExc_ValueError, "invalid channel reference");
         return NULL;
     }
 
-    if (!PyCapsule_CheckExact(loop_capsule)) {
-        PyErr_SetString(PyExc_TypeError, "expected loop capsule");
-        return NULL;
-    }
-
-    erlang_event_loop_t *loop = (erlang_event_loop_t *)PyCapsule_GetPointer(loop_capsule, "erlang_python.event_loop");
+    erlang_event_loop_t *loop = (erlang_event_loop_t *)get_capsule_pointer_or_fail(
+        loop_capsule, "erlang_python.event_loop", "loop");
     if (loop == NULL) {
-        PyErr_SetString(PyExc_ValueError, "invalid loop reference");
         return NULL;
     }
 
@@ -3090,14 +3002,9 @@ static PyObject *erlang_channel_cancel_wait_impl(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    if (!PyCapsule_CheckExact(ch_capsule)) {
-        PyErr_SetString(PyExc_TypeError, "expected channel reference");
-        return NULL;
-    }
-
-    py_channel_t *channel = (py_channel_t *)PyCapsule_GetPointer(ch_capsule, CHANNEL_CAPSULE_NAME);
+    py_channel_t *channel = (py_channel_t *)get_capsule_pointer_or_fail(
+        ch_capsule, CHANNEL_CAPSULE_NAME, "channel");
     if (channel == NULL) {
-        PyErr_SetString(PyExc_ValueError, "invalid channel reference");
         return NULL;
     }
 
@@ -3136,25 +3043,15 @@ static PyObject *erlang_byte_channel_wait_impl(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    if (!PyCapsule_CheckExact(ch_capsule)) {
-        PyErr_SetString(PyExc_TypeError, "expected channel reference");
-        return NULL;
-    }
-
-    py_channel_t *channel = (py_channel_t *)PyCapsule_GetPointer(ch_capsule, CHANNEL_CAPSULE_NAME);
+    py_channel_t *channel = (py_channel_t *)get_capsule_pointer_or_fail(
+        ch_capsule, CHANNEL_CAPSULE_NAME, "channel");
     if (channel == NULL) {
-        PyErr_SetString(PyExc_ValueError, "invalid channel reference");
         return NULL;
     }
 
-    if (!PyCapsule_CheckExact(loop_capsule)) {
-        PyErr_SetString(PyExc_TypeError, "expected loop capsule");
-        return NULL;
-    }
-
-    erlang_event_loop_t *loop = (erlang_event_loop_t *)PyCapsule_GetPointer(loop_capsule, "erlang_python.event_loop");
+    erlang_event_loop_t *loop = (erlang_event_loop_t *)get_capsule_pointer_or_fail(
+        loop_capsule, "erlang_python.event_loop", "loop");
     if (loop == NULL) {
-        PyErr_SetString(PyExc_ValueError, "invalid loop reference");
         return NULL;
     }
 

--- a/c_src/py_event_loop.c
+++ b/c_src/py_event_loop.c
@@ -1292,29 +1292,27 @@ ERL_NIF_TERM nif_event_loop_set_id(ErlNifEnv *env, int argc,
     return ATOM_OK;
 }
 
+/* ============================================================================
+ * FD Watcher Helpers (consolidated reader/writer logic)
+ * ============================================================================ */
+
 /**
- * add_reader(LoopRef, Fd, CallbackId) -> {ok, FdRef}
+ * @brief Add an fd watcher (reader or writer)
+ *
+ * Consolidated helper for nif_add_reader and nif_add_writer.
+ * Allocates fd resource, sets up monitoring, and registers with scheduler.
+ *
+ * @param env NIF environment
+ * @param loop Event loop
+ * @param fd File descriptor to watch
+ * @param callback_id Callback ID for when fd is ready
+ * @param select_mode ERL_NIF_SELECT_READ or ERL_NIF_SELECT_WRITE
+ * @param is_reader true for reader, false for writer
+ * @return {ok, FdRef} or {error, Reason}
  */
-ERL_NIF_TERM nif_add_reader(ErlNifEnv *env, int argc,
-                            const ERL_NIF_TERM argv[]) {
-    (void)argc;
-
-    erlang_event_loop_t *loop;
-    if (!enif_get_resource(env, argv[0], EVENT_LOOP_RESOURCE_TYPE,
-                           (void **)&loop)) {
-        return make_error(env, "invalid_loop");
-    }
-
-    int fd;
-    if (!enif_get_int(env, argv[1], &fd)) {
-        return make_error(env, "invalid_fd");
-    }
-
-    ErlNifUInt64 callback_id;
-    if (!enif_get_uint64(env, argv[2], &callback_id)) {
-        return make_error(env, "invalid_callback_id");
-    }
-
+static ERL_NIF_TERM add_fd_watcher(ErlNifEnv *env, erlang_event_loop_t *loop,
+                                    int fd, ErlNifUInt64 callback_id,
+                                    int select_mode, bool is_reader) {
     /* Scalable I/O: prefer worker, fall back to router */
     if (!event_loop_ensure_worker(loop)) {
         return make_error(env, "no_router");
@@ -1329,11 +1327,11 @@ ERL_NIF_TERM nif_add_reader(ErlNifEnv *env, int argc,
     }
 
     fd_res->fd = fd;
-    fd_res->read_callback_id = callback_id;
-    fd_res->write_callback_id = 0;
+    fd_res->read_callback_id = is_reader ? callback_id : 0;
+    fd_res->write_callback_id = is_reader ? 0 : callback_id;
     fd_res->owner_pid = *target_pid;
-    fd_res->reader_active = true;
-    fd_res->writer_active = false;
+    fd_res->reader_active = is_reader;
+    fd_res->writer_active = !is_reader;
     fd_res->loop = loop;
 
     /* Initialize lifecycle management fields */
@@ -1347,8 +1345,8 @@ ERL_NIF_TERM nif_add_reader(ErlNifEnv *env, int argc,
         fd_res->monitor_active = true;
     }
 
-    /* Register with Erlang scheduler for read monitoring */
-    int ret = enif_select(env, (ErlNifEvent)fd, ERL_NIF_SELECT_READ,
+    /* Register with Erlang scheduler for monitoring */
+    int ret = enif_select(env, (ErlNifEvent)fd, select_mode,
                           fd_res, target_pid, enif_make_ref(env));
 
     if (ret < 0) {
@@ -1360,10 +1358,66 @@ ERL_NIF_TERM nif_add_reader(ErlNifEnv *env, int argc,
     }
 
     ERL_NIF_TERM fd_term = enif_make_resource(env, fd_res);
-    /* Keep the owner's reference - will be released in remove_reader.
+    /* Keep the owner's reference - will be released in remove_reader/writer.
      * This ensures the fd_res stays alive while registered for select. */
 
     return enif_make_tuple2(env, ATOM_OK, fd_term);
+}
+
+/**
+ * @brief Remove an fd watcher (reader or writer)
+ *
+ * Consolidated helper for nif_remove_reader and nif_remove_writer.
+ *
+ * @param env NIF environment
+ * @param fd_res FD resource to remove
+ * @param is_reader true for reader, false for writer
+ * @return ok
+ */
+static ERL_NIF_TERM remove_fd_watcher(ErlNifEnv *env, fd_resource_t *fd_res,
+                                       bool is_reader) {
+    bool *active_flag = is_reader ? &fd_res->reader_active : &fd_res->writer_active;
+    bool *other_flag = is_reader ? &fd_res->writer_active : &fd_res->reader_active;
+
+    if (!*active_flag) {
+        return ATOM_OK;  /* Already removed */
+    }
+
+    /* Stop monitoring using the same resource */
+    enif_select(env, (ErlNifEvent)fd_res->fd, ERL_NIF_SELECT_STOP,
+                fd_res, NULL, enif_make_atom(env, "undefined"));
+
+    *active_flag = false;
+
+    /* Release the owner's reference that was kept in add_reader/writer */
+    if (!*other_flag) {
+        enif_release_resource(fd_res);
+    }
+
+    return ATOM_OK;
+}
+
+/**
+ * add_reader(LoopRef, Fd, CallbackId) -> {ok, FdRef}
+ */
+ERL_NIF_TERM nif_add_reader(ErlNifEnv *env, int argc,
+                            const ERL_NIF_TERM argv[]) {
+    (void)argc;
+
+    erlang_event_loop_t *loop;
+    GET_RESOURCE_OR_FAIL(loop, env, argv[0], EVENT_LOOP_RESOURCE_TYPE, "invalid_loop");
+
+    int fd;
+    if (!enif_get_int(env, argv[1], &fd)) {
+        return make_error(env, "invalid_fd");
+    }
+
+    ErlNifUInt64 callback_id;
+    if (!enif_get_uint64(env, argv[2], &callback_id)) {
+        return make_error(env, "invalid_callback_id");
+    }
+
+    return add_fd_watcher(env, loop, fd, callback_id, ERL_NIF_SELECT_READ, true);
 }
 
 /**
@@ -1376,32 +1430,13 @@ ERL_NIF_TERM nif_remove_reader(ErlNifEnv *env, int argc,
     (void)argc;
 
     erlang_event_loop_t *loop;
-    if (!enif_get_resource(env, argv[0], EVENT_LOOP_RESOURCE_TYPE,
-                           (void **)&loop)) {
-        return make_error(env, "invalid_loop");
-    }
+    GET_RESOURCE_OR_FAIL(loop, env, argv[0], EVENT_LOOP_RESOURCE_TYPE, "invalid_loop");
+    (void)loop;  /* Used for validation only */
 
     fd_resource_t *fd_res;
-    if (!enif_get_resource(env, argv[1], FD_RESOURCE_TYPE, (void **)&fd_res)) {
-        return make_error(env, "invalid_fd_ref");
-    }
+    GET_RESOURCE_OR_FAIL(fd_res, env, argv[1], FD_RESOURCE_TYPE, "invalid_fd_ref");
 
-    if (!fd_res->reader_active) {
-        return ATOM_OK;  /* Already removed */
-    }
-
-    /* Stop monitoring for reads using the same resource */
-    enif_select(env, (ErlNifEvent)fd_res->fd, ERL_NIF_SELECT_STOP,
-                fd_res, NULL, enif_make_atom(env, "undefined"));
-
-    fd_res->reader_active = false;
-
-    /* Release the owner's reference that was kept in add_reader */
-    if (!fd_res->writer_active) {
-        enif_release_resource(fd_res);
-    }
-
-    return ATOM_OK;
+    return remove_fd_watcher(env, fd_res, true);
 }
 
 /**
@@ -1412,10 +1447,7 @@ ERL_NIF_TERM nif_add_writer(ErlNifEnv *env, int argc,
     (void)argc;
 
     erlang_event_loop_t *loop;
-    if (!enif_get_resource(env, argv[0], EVENT_LOOP_RESOURCE_TYPE,
-                           (void **)&loop)) {
-        return make_error(env, "invalid_loop");
-    }
+    GET_RESOURCE_OR_FAIL(loop, env, argv[0], EVENT_LOOP_RESOURCE_TYPE, "invalid_loop");
 
     int fd;
     if (!enif_get_int(env, argv[1], &fd)) {
@@ -1427,55 +1459,7 @@ ERL_NIF_TERM nif_add_writer(ErlNifEnv *env, int argc,
         return make_error(env, "invalid_callback_id");
     }
 
-    /* Scalable I/O: prefer worker, fall back to router */
-    if (!event_loop_ensure_worker(loop)) {
-        return make_error(env, "no_router");
-    }
-    ErlNifPid *target_pid = &loop->worker_pid;
-
-    /* Allocate fd resource */
-    fd_resource_t *fd_res = enif_alloc_resource(FD_RESOURCE_TYPE,
-                                                 sizeof(fd_resource_t));
-    if (fd_res == NULL) {
-        return make_error(env, "alloc_failed");
-    }
-
-    fd_res->fd = fd;
-    fd_res->read_callback_id = 0;
-    fd_res->write_callback_id = callback_id;
-    fd_res->owner_pid = *target_pid;
-    fd_res->reader_active = false;
-    fd_res->writer_active = true;
-    fd_res->loop = loop;
-
-    /* Initialize lifecycle management fields */
-    atomic_store(&fd_res->closing_state, FD_STATE_OPEN);
-    fd_res->monitor_active = false;
-    fd_res->owns_fd = false;
-
-    /* Monitor owner process for cleanup on death */
-    if (enif_monitor_process(env, fd_res, target_pid,
-                             &fd_res->owner_monitor) == 0) {
-        fd_res->monitor_active = true;
-    }
-
-    /* Register with Erlang scheduler for write monitoring */
-    int ret = enif_select(env, (ErlNifEvent)fd, ERL_NIF_SELECT_WRITE,
-                          fd_res, target_pid, enif_make_ref(env));
-
-    if (ret < 0) {
-        if (fd_res->monitor_active) {
-            enif_demonitor_process(env, fd_res, &fd_res->owner_monitor);
-        }
-        enif_release_resource(fd_res);
-        return make_error(env, "select_failed");
-    }
-
-    ERL_NIF_TERM fd_term = enif_make_resource(env, fd_res);
-    /* Keep the owner's reference - will be released in remove_writer.
-     * This ensures the fd_res stays alive while registered for select. */
-
-    return enif_make_tuple2(env, ATOM_OK, fd_term);
+    return add_fd_watcher(env, loop, fd, callback_id, ERL_NIF_SELECT_WRITE, false);
 }
 
 /**
@@ -1488,32 +1472,13 @@ ERL_NIF_TERM nif_remove_writer(ErlNifEnv *env, int argc,
     (void)argc;
 
     erlang_event_loop_t *loop;
-    if (!enif_get_resource(env, argv[0], EVENT_LOOP_RESOURCE_TYPE,
-                           (void **)&loop)) {
-        return make_error(env, "invalid_loop");
-    }
+    GET_RESOURCE_OR_FAIL(loop, env, argv[0], EVENT_LOOP_RESOURCE_TYPE, "invalid_loop");
+    (void)loop;  /* Used for validation only */
 
     fd_resource_t *fd_res;
-    if (!enif_get_resource(env, argv[1], FD_RESOURCE_TYPE, (void **)&fd_res)) {
-        return make_error(env, "invalid_fd_ref");
-    }
+    GET_RESOURCE_OR_FAIL(fd_res, env, argv[1], FD_RESOURCE_TYPE, "invalid_fd_ref");
 
-    if (!fd_res->writer_active) {
-        return ATOM_OK;  /* Already removed */
-    }
-
-    /* Stop monitoring for writes using the same resource */
-    enif_select(env, (ErlNifEvent)fd_res->fd, ERL_NIF_SELECT_STOP,
-                fd_res, NULL, enif_make_atom(env, "undefined"));
-
-    fd_res->writer_active = false;
-
-    /* Release the owner's reference that was kept in add_writer */
-    if (!fd_res->reader_active) {
-        enif_release_resource(fd_res);
-    }
-
-    return ATOM_OK;
+    return remove_fd_watcher(env, fd_res, false);
 }
 
 /**

--- a/c_src/py_nif.c
+++ b/c_src/py_nif.c
@@ -1518,10 +1518,7 @@ static ERL_NIF_TERM nif_worker_new(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
 static ERL_NIF_TERM nif_worker_destroy(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     (void)argc;
     py_worker_t *worker;
-
-    if (!enif_get_resource(env, argv[0], WORKER_RESOURCE_TYPE, (void **)&worker)) {
-        return make_error(env, "invalid_worker");
-    }
+    GET_RESOURCE_OR_FAIL(worker, env, argv[0], WORKER_RESOURCE_TYPE, "invalid_worker");
 
     /* Resource destructor will handle cleanup */
     return ATOM_OK;
@@ -1533,10 +1530,7 @@ static ERL_NIF_TERM nif_worker_destroy(ErlNifEnv *env, int argc, const ERL_NIF_T
 
 static ERL_NIF_TERM nif_worker_call(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     py_worker_t *worker;
-
-    if (!enif_get_resource(env, argv[0], WORKER_RESOURCE_TYPE, (void **)&worker)) {
-        return make_error(env, "invalid_worker");
-    }
+    GET_RESOURCE_OR_FAIL(worker, env, argv[0], WORKER_RESOURCE_TYPE, "invalid_worker");
 
     /* Build request and route to executor */
     py_request_t req;
@@ -1576,10 +1570,7 @@ static ERL_NIF_TERM nif_worker_call(ErlNifEnv *env, int argc, const ERL_NIF_TERM
 
 static ERL_NIF_TERM nif_worker_eval(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     py_worker_t *worker;
-
-    if (!enif_get_resource(env, argv[0], WORKER_RESOURCE_TYPE, (void **)&worker)) {
-        return make_error(env, "invalid_worker");
-    }
+    GET_RESOURCE_OR_FAIL(worker, env, argv[0], WORKER_RESOURCE_TYPE, "invalid_worker");
 
     py_request_t req;
     request_init(&req);
@@ -1612,10 +1603,7 @@ static ERL_NIF_TERM nif_worker_eval(ErlNifEnv *env, int argc, const ERL_NIF_TERM
 static ERL_NIF_TERM nif_worker_exec(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     (void)argc;
     py_worker_t *worker;
-
-    if (!enif_get_resource(env, argv[0], WORKER_RESOURCE_TYPE, (void **)&worker)) {
-        return make_error(env, "invalid_worker");
-    }
+    GET_RESOURCE_OR_FAIL(worker, env, argv[0], WORKER_RESOURCE_TYPE, "invalid_worker");
 
     py_request_t req;
     request_init(&req);
@@ -1643,13 +1631,8 @@ static ERL_NIF_TERM nif_worker_next(ErlNifEnv *env, int argc, const ERL_NIF_TERM
     (void)argc;
     py_worker_t *worker;
     py_object_t *gen_wrapper;
-
-    if (!enif_get_resource(env, argv[0], WORKER_RESOURCE_TYPE, (void **)&worker)) {
-        return make_error(env, "invalid_worker");
-    }
-    if (!enif_get_resource(env, argv[1], PYOBJ_RESOURCE_TYPE, (void **)&gen_wrapper)) {
-        return make_error(env, "invalid_generator");
-    }
+    GET_RESOURCE_OR_FAIL(worker, env, argv[0], WORKER_RESOURCE_TYPE, "invalid_worker");
+    GET_RESOURCE_OR_FAIL(gen_wrapper, env, argv[1], PYOBJ_RESOURCE_TYPE, "invalid_generator");
 
     py_request_t req;
     request_init(&req);
@@ -1672,10 +1655,7 @@ static ERL_NIF_TERM nif_worker_next(ErlNifEnv *env, int argc, const ERL_NIF_TERM
 static ERL_NIF_TERM nif_import_module(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     (void)argc;
     py_worker_t *worker;
-
-    if (!enif_get_resource(env, argv[0], WORKER_RESOURCE_TYPE, (void **)&worker)) {
-        return make_error(env, "invalid_worker");
-    }
+    GET_RESOURCE_OR_FAIL(worker, env, argv[0], WORKER_RESOURCE_TYPE, "invalid_worker");
 
     py_request_t req;
     request_init(&req);
@@ -1703,13 +1683,8 @@ static ERL_NIF_TERM nif_get_attr(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
     (void)argc;
     py_worker_t *worker;
     py_object_t *obj_wrapper;
-
-    if (!enif_get_resource(env, argv[0], WORKER_RESOURCE_TYPE, (void **)&worker)) {
-        return make_error(env, "invalid_worker");
-    }
-    if (!enif_get_resource(env, argv[1], PYOBJ_RESOURCE_TYPE, (void **)&obj_wrapper)) {
-        return make_error(env, "invalid_object");
-    }
+    GET_RESOURCE_OR_FAIL(worker, env, argv[0], WORKER_RESOURCE_TYPE, "invalid_worker");
+    GET_RESOURCE_OR_FAIL(obj_wrapper, env, argv[1], PYOBJ_RESOURCE_TYPE, "invalid_object");
 
     py_request_t req;
     request_init(&req);
@@ -4433,10 +4408,7 @@ static ERL_NIF_TERM nif_context_create(ErlNifEnv *env, int argc, const ERL_NIF_T
 static ERL_NIF_TERM nif_context_destroy(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     (void)argc;
     py_context_t *ctx;
-
-    if (!enif_get_resource(env, argv[0], PY_CONTEXT_RESOURCE_TYPE, (void **)&ctx)) {
-        return make_error(env, "invalid_context");
-    }
+    GET_RESOURCE_OR_FAIL(ctx, env, argv[0], PY_CONTEXT_RESOURCE_TYPE, "invalid_context");
 
     /* Skip if already destroyed */
     if (ctx->destroyed) {

--- a/c_src/py_nif.h
+++ b/c_src/py_nif.h
@@ -1650,6 +1650,135 @@ static char *binary_to_string(const ErlNifBinary *bin) {
     return str;
 }
 
+/* ============================================================================
+ * Refactoring Helper Macros
+ * ============================================================================
+ * These macros consolidate common patterns across py_nif.c, py_callback.c,
+ * and py_event_loop.c to reduce code duplication.
+ */
+
+/**
+ * @brief Null-safe free macro
+ *
+ * Safely frees a pointer and sets it to NULL. Avoids undefined behavior
+ * from calling enif_free(NULL) and prevents double-free bugs.
+ *
+ * @param ptr Pointer to free (will be set to NULL after free)
+ */
+#define SAFE_FREE(ptr) do { \
+    if ((ptr) != NULL) { \
+        enif_free(ptr); \
+        (ptr) = NULL; \
+    } \
+} while(0)
+
+/**
+ * @brief Get resource or return error
+ *
+ * Validates and extracts a resource from an Erlang term. On failure,
+ * returns an error tuple immediately.
+ *
+ * @param var Variable to store the resource pointer
+ * @param env NIF environment
+ * @param term Erlang term containing the resource
+ * @param type Resource type
+ * @param err Error string to return on failure
+ */
+#define GET_RESOURCE_OR_FAIL(var, env, term, type, err) \
+    do { \
+        if (!enif_get_resource(env, term, type, (void **)&(var))) { \
+            return make_error(env, err); \
+        } \
+    } while(0)
+
+/**
+ * @brief Get binary or return error
+ *
+ * Validates and extracts a binary from an Erlang term. On failure,
+ * returns an error tuple immediately.
+ *
+ * @param var ErlNifBinary variable to store the binary
+ * @param env NIF environment
+ * @param term Erlang term containing the binary
+ * @param err Error string to return on failure
+ */
+#define GET_BINARY_OR_FAIL(var, env, term, err) \
+    do { \
+        if (!enif_inspect_binary(env, term, &(var))) { \
+            return make_error(env, err); \
+        } \
+    } while(0)
+
+/**
+ * @brief Check if GIL can be safely acquired
+ *
+ * Returns true if it's safe to call PyGILState_Ensure. This check ensures:
+ * - Python runtime is running
+ * - Current thread doesn't already have a thread state bound
+ * - GIL is not already held by current thread
+ *
+ * @return true if safe to acquire GIL, false otherwise
+ */
+#define CAN_ACQUIRE_GIL() \
+    (runtime_is_running() && \
+     PyGILState_GetThisThreadState() == NULL && \
+     !PyGILState_Check())
+
+/**
+ * @brief Get channel from PyCapsule with validation
+ *
+ * Extracts a py_channel_t pointer from a PyCapsule with proper validation.
+ * Sets Python exception on failure.
+ *
+ * @param capsule Python capsule object
+ * @param capsule_name Expected capsule name
+ * @return Channel pointer or NULL with exception set
+ */
+static inline void *get_capsule_pointer_or_fail(PyObject *capsule, const char *capsule_name,
+                                                 const char *type_name) {
+    if (!PyCapsule_CheckExact(capsule)) {
+        PyErr_Format(PyExc_TypeError, "expected %s reference", type_name);
+        return NULL;
+    }
+    void *ptr = PyCapsule_GetPointer(capsule, capsule_name);
+    if (ptr == NULL) {
+        PyErr_Format(PyExc_ValueError, "invalid %s reference", type_name);
+    }
+    return ptr;
+}
+
+/**
+ * @brief Decode ETF data to Python object
+ *
+ * Decodes Erlang external term format data to a Python object.
+ * Handles environment allocation/cleanup and error handling.
+ *
+ * @param data ETF data buffer (will be freed on success or failure)
+ * @param size Size of data buffer
+ * @return Python object or NULL with exception set
+ */
+static inline PyObject *decode_etf_to_python(unsigned char *data, size_t size) {
+    ErlNifEnv *tmp_env = enif_alloc_env();
+    if (tmp_env == NULL) {
+        enif_free(data);
+        PyErr_SetString(PyExc_MemoryError, "failed to allocate environment");
+        return NULL;
+    }
+
+    ERL_NIF_TERM term;
+    if (enif_binary_to_term(tmp_env, data, size, &term, 0) == 0) {
+        enif_free(data);
+        enif_free_env(tmp_env);
+        PyErr_SetString(PyExc_RuntimeError, "failed to decode term");
+        return NULL;
+    }
+    enif_free(data);
+
+    PyObject *obj = term_to_py(tmp_env, term);
+    enif_free_env(tmp_env);
+    return obj;
+}
+
 /**
  * @brief Read from a file descriptor with optional timeout
  *


### PR DESCRIPTION
## Summary

- Add shared helper macros to py_nif.h (SAFE_FREE, GET_RESOURCE_OR_FAIL, etc.)
- Consolidate nif_add_reader/nif_add_writer into add_fd_watcher() helper
- Consolidate nif_remove_reader/nif_remove_writer into remove_fd_watcher() helper
- Replace PyCapsule validation patterns with get_capsule_pointer_or_fail()
- Replace ETF decoding blocks with decode_etf_to_python() helper
- Apply macros to worker functions in py_nif.c

Net reduction: ~37 lines (248 added, 285 removed)