### PR TITLE
Lower minimum OTP to 27 and validate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Linux - OTP 27 (minimum supported)
+          - os: ubuntu-24.04
+            otp: "27"
+            python: "3.12"
+          - os: ubuntu-24.04
+            otp: "27"
+            python: "3.13"
+          - os: ubuntu-24.04
+            otp: "27"
+            python: "3.14"
           # Linux - OTP 28
           - os: ubuntu-24.04
             otp: "28"
@@ -130,7 +140,7 @@ jobs:
           usesh: true
           prepare: |
             # Stock `erlang` pkg lags at OTP 26; use the versioned runtime
-            # package so we test on a supported OTP (28+).
+            # package so we test on a supported OTP (27+).
             pkg install -y erlang-runtime28 ${{ matrix.python_pkg }} cmake
             # numpy package follows the py<noDot>-numpy convention.
             # Non-fatal: not every FreeBSD pkg snapshot ships numpy for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **Lower minimum OTP to 27** - `minimum_otp_vsn` is now `27`. The OTP 28/29
+  support work was source-compatible with 27 (the `try ... catch` cleanups build
+  fine there), so the floor was raised further than needed. CI now also builds and
+  runs the full Common Test suite on OTP 27 across Python 3.12/3.13/3.14.
+
 ## 3.1.0 (2026-05-30)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Key features:
 
 ## Requirements
 
-- Erlang/OTP 28+ (tested on OTP 28 and 29)
+- Erlang/OTP 27+ (tested on OTP 27, 28, and 29)
 - Python 3.12+ (3.13+ for free-threading)
 - C compiler (gcc, clang)
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 
-{minimum_otp_vsn, "28"}.
+{minimum_otp_vsn, "27"}.
 
 {xref_checks, [
     undefined_function_calls,


### PR DESCRIPTION
Lowers the supported OTP floor from 28 back to 27.

The OTP 28/29 support work was source-compatible with 27 (the `try ... catch` cleanups build fine there), so the `minimum_otp_vsn` floor had been raised further than necessary. Nothing in the Erlang or C sources depends on an OTP 28-only API.

## Changes
- `rebar.config`: `minimum_otp_vsn` 28 -> 27
- `.github/workflows/ci.yml`: add OTP 27 Linux block (Python 3.12/3.13/3.14), mirroring the OTP 28 rows; matrix is now 27/28 on Linux + 29 on Linux/macOS
- `README.md`: requirements now read "Erlang/OTP 27+ (tested on OTP 27, 28, and 29)"
- `CHANGELOG.md`: Unreleased entry

Auxiliary jobs (asan, free-threaded, lint, docs) stay on OTP 29 since they test orthogonal concerns, not version compatibility.

Actual OTP 27 validation happens in this PR's CI run (local dev machine only has OTP 29).