### PR TITLE
Release 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.1.1 (2026-05-31)
 
 ### Changed
 

--- a/src/erlang_python.app.src
+++ b/src/erlang_python.app.src
@@ -1,6 +1,6 @@
 {application, erlang_python, [
     {description, "Execute Python applications from Erlang using dirty NIFs"},
-    {vsn, "3.1.0"},
+    {vsn, "3.1.1"},
     {registered, []},
     {mod, {erlang_python_app, []}},
     {applications, [


### PR DESCRIPTION
Patch release for the OTP 27 floor change (#68).

- `src/erlang_python.app.src`: vsn 3.1.0 -> 3.1.1
- `CHANGELOG.md`: date the 3.1.1 entry (2026-05-31)

Patch bump since the change only expands the supported OTP range; no API or breaking changes.